### PR TITLE
[WIP] Upload files to the origin server

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -60,7 +60,7 @@ GENTOO_MIRRORS="${GENTOO_MIRRORS//https:\/\//http://}"
 export GENTOO_MIRRORS
 
 catalyst_init "$@"
-check_gsutil_opts
+check_upload_opts
 
 if [[ "$STAGES" =~ stage4 ]]; then
     info "Setting release to ${COREOS_VERSION}"

--- a/build_image
+++ b/build_image
@@ -88,7 +88,7 @@ eval set -- "${FLAGS_ARGV:-prod}"
 # so will die prematurely if 'switch_to_strict_mode' is specified before now.
 switch_to_strict_mode
 
-check_gsutil_opts
+check_upload_opts
 
 # Patch around default values not being able to depend on other flags.
 if [ "x${FLAGS_torcx_manifest}" = "x${DEFAULT_BUILD_ROOT}/torcx/${DEFAULT_BOARD}/latest/torcx_manifest.json" ]; then

--- a/build_packages
+++ b/build_packages
@@ -84,7 +84,7 @@ if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
   FLAGS_workon="${FLAGS_FALSE}"
 fi
 
-check_gsutil_opts
+check_upload_opts
 
 CHROMITE_BIN="${GCLIENT_ROOT}/chromite/bin"
 

--- a/build_toolchains
+++ b/build_toolchains
@@ -30,7 +30,7 @@ catalyst_stage_default
 }
 
 catalyst_init "$@"
-check_gsutil_opts
+check_upload_opts
 
 # toolchain_util.sh is required by catalyst_toolchains.sh
 mkdir -p "${ROOT_OVERLAY}/tmp"

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -48,7 +48,7 @@ eval set -- "${FLAGS_ARGV}"
 switch_to_strict_mode
 
 # Initialize upload options
-check_gsutil_opts
+check_upload_opts
 
 # Define BUILD_DIR and set_build_symlinks.
 . "${BUILD_LIBRARY_DIR}/toolchain_util.sh" || exit 1

--- a/image_inject_bootchain
+++ b/image_inject_bootchain
@@ -50,7 +50,7 @@ eval set -- "${FLAGS_ARGV}"
 # Die on any errors.
 switch_to_strict_mode
 
-check_gsutil_opts
+check_upload_opts
 
 if [[ -z "${FLAGS_kernel_path}" && -z "${FLAGS_efi_grub_path}" &&
         -z "${FLAGS_shim_path}" ]]; then

--- a/image_set_group
+++ b/image_set_group
@@ -42,7 +42,7 @@ eval set -- "${FLAGS_ARGV}"
 # Die on any errors.
 switch_to_strict_mode
 
-check_gsutil_opts
+check_upload_opts
 
 if [[ -z "${FLAGS_board}" ]] ; then
   die_notrace "--board is required."

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -57,7 +57,7 @@ eval set -- "${FLAGS_ARGV}"
 # Die on any errors.
 switch_to_strict_mode
 
-check_gsutil_opts
+check_upload_opts
 
 if [[ -z "${FLAGS_format}" ]]; then
     FLAGS_format="$(get_default_vm_type ${FLAGS_board})"

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+ORIGIN_SERVER="origin.release.flatcar-linux.net"
+REMOTE_UPLOAD_DIR="/var/www/origin.release.flatcar-linux.net/test"
+UPLOAD_ROOT="${ORIGIN_SERVER}:${REMOTE_UPLOAD_DIR}"
+
 # Clear out old images.
 sudo rm -rf chroot/build src/build torcx
 
@@ -73,4 +77,5 @@ script build_image \
     --torcx_manifest=/mnt/host/source/torcx/torcx_manifest.json \
     --torcx_root=/mnt/host/source/torcx/ \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --upload prod container

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+ORIGIN_SERVER="origin.release.flatcar-linux.net"
+REMOTE_UPLOAD_DIR="/var/www/origin.release.flatcar-linux.net/test"
+UPLOAD_ROOT="${ORIGIN_SERVER}:${REMOTE_UPLOAD_DIR}"
+
 # Use a ccache dir that persists across SDK recreations.
 # XXX: alternatively use a ccache dir that is usable by all jobs on a given node.
 mkdir -p .cache/ccache
@@ -49,6 +53,7 @@ script build_packages \
     --sign="${SIGNING_USER}" \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --upload
 
 script build_torcx_store \
@@ -56,6 +61,7 @@ script build_torcx_store \
     --sign="${SIGNING_USER}" \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --torcx_upload_root="${TORCX_PKG_DOWNLOAD_ROOT}" \
     --tectonic_torcx_download_root="${TECTONIC_TORCX_DOWNLOAD_ROOT}" \
     --upload

--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+ORIGIN_SERVER="origin.release.flatcar-linux.net"
+REMOTE_UPLOAD_DIR="/var/www/origin.release.flatcar-linux.net/test"
+UPLOAD_ROOT="${ORIGIN_SERVER}:${REMOTE_UPLOAD_DIR}"
+
 enter() {
         bin/cork enter --experimental -- "$@"
 }
@@ -20,6 +24,7 @@ enter sudo ${S}/bootstrap_sdk \
     --sign="${SIGNING_USER}" \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --upload
 
 # Free some disk space only on success to allow debugging failures.

--- a/jenkins/toolchains.sh
+++ b/jenkins/toolchains.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+ORIGIN_SERVER="origin.release.flatcar-linux.net"
+REMOTE_UPLOAD_DIR="/var/www/origin.release.flatcar-linux.net/test"
+UPLOAD_ROOT="${ORIGIN_SERVER}:${REMOTE_UPLOAD_DIR}"
+
 enter() {
         bin/cork enter --experimental -- "$@"
 }
@@ -19,6 +23,7 @@ enter sudo ${S}/build_toolchains \
     --sign="${SIGNING_USER}" \
     --sign_digests="${SIGNING_USER}" \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --upload
 
 # Free some disk space only on success to allow debugging failures.

--- a/jenkins/vm.sh
+++ b/jenkins/vm.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+ORIGIN_SERVER="origin.release.flatcar-linux.net"
+REMOTE_UPLOAD_DIR="/var/www/origin.release.flatcar-linux.net/test"
+UPLOAD_ROOT="${ORIGIN_SERVER}:${REMOTE_UPLOAD_DIR}"
+
 # Clear out old images.
 sudo rm -rf chroot/build tmp
 
@@ -53,4 +57,5 @@ script image_to_vm.sh \
     --sign_digests="${SIGNING_USER}" \
     --download_root="${DOWNLOAD_ROOT}" \
     --upload_root="${UPLOAD_ROOT}" \
+    --upload_type="sftp" \
     --upload

--- a/rebuild_packages
+++ b/rebuild_packages
@@ -31,7 +31,7 @@ if [[ -z "${FLAGS_board}" ]]; then
   exit 1
 fi
 
-check_gsutil_opts
+check_upload_opts
 
 # set BOARD and BOARD_ROOT
 . "${BUILD_LIBRARY_DIR}/toolchain_util.sh" || exit 1


### PR DESCRIPTION
Allow different types of remote repos where the images are uploaded. The type can be either `"gs"` (Google Storage, which is default), or `"sftp"` (file server that is accessible via sftp).

Explicitly set `--upload_type=sftp` for Jenkins scripts, instead of uploading to Google Storage. Doing that, we can first upload images to the flatcar origin server, and later we can sync repos with Google Storage buckets using `sync-rclone`.

**Work-in-progress. completely untested**