### PR TITLE
sdk_lib: download Flatcar SDK in a graceful way

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -197,7 +197,7 @@ catalyst_init() {
 
     # automatically download the current SDK if it is the seed tarball.
     if [[ "$FLAGS_seed_tarball" == "${FLATCAR_SDK_TARBALL_PATH}" ]]; then
-        sdk_download_tarball
+        sdk_download_tarball_graceful
     fi
 
     # confirm seed exists


### PR DESCRIPTION
If the given Flatcar SDK tarball is not available on the remote server, it should fall back to the next recent version available.

Doing that, we can deal with occasional download failures that occur when the given SDK was not properly built for some reasons.