### PR TITLE
build_library: fix Flatcar-specific download path from GCS

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -229,9 +229,14 @@ download_image_url() {
     local download_root="${FLAGS_download_root:-${UPLOAD_ROOT}}"
 
     local download_path
+    local download_channel
     if [[ -n "${FLAGS_download_path}" ]]; then
         download_path="${FLAGS_download_path%%/}"
-    elif [[ "${download_root}" = *release.core-os.net* ]]; then
+    elif [[ "${download_root}" = *flatcar-jenkins* ]]; then
+        if [[ "${download_path}" == gs://* ]]; then
+            download_channel="${download_root##*/}"
+            download_root="gs://${download_channel}.release.flatcar-linux.net"
+        fi
         # Official release download paths don't include the boards directory
         download_path="${download_root%%/}/${BOARD}/${FLATCAR_VERSION}"
     else
@@ -240,7 +245,7 @@ download_image_url() {
 
     # Just in case download_root was set from UPLOAD_ROOT
     if [[ "${download_path}" == gs://* ]]; then
-        download_path="http://${download_path#gs://}"
+        download_path="https://${download_path#gs://}"
     fi
 
     echo "${download_path}/$1"


### PR DESCRIPTION
There has been an issue with vagrant json files where `url` field is set to an invalid URL. For example, in https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json, `url` is `gs://flatcar-jenkins/alpha/amd64-usr/2023.0.0/flatcar_production_vagrant.box`. It should be actually https://alpha.release.flatcar-linux.net/amd64-usr/2023.0.0/flatcar_production_vagrant.box.

Its reason is, the function `download_image_url()` in release_util.sh simply assumes that the input variable `download_root` includes `gs://builds.release.core-os.net/alpha` in `GS_RELEASE_ROOT` of resource variables. That's true only for Container Linux. In case of Flatcar, the `download_root` is actually `gs://flatcar-jenkins/alpha`.

What we should do here is to check for `flatcar-jenkins` in download_root. If it's true, reconstruct the download_path as `<channel name>.release.flatcar-linux.net/...`.
Also we should change `http` to `https` to be used for Flatcar servers.

Doing that, we will not need to run `fix_vagrant.sh` for every release.

See also https://github.com/flatcar-linux/Flatcar/issues/1