### PR TITLE
build_library: enlarge rootfs size to 6G for dev container

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -131,7 +131,7 @@
         "label":"ROOT",
         "fs_label":"ROOT",
         "type":"4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
-        "blocks":"6291456"
+        "blocks":"12582912"
       }
     },
     "interoute":{


### PR DESCRIPTION
Since the developer container image is only 3G in size for its rootfs, it's hard for users to do specific work there, for example, to build kernel modules.

Let's increase the size of rootfs to 6G.