### PR TITLE
build_library: set download_path even if its input is empty

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -232,11 +232,9 @@ download_image_url() {
     local download_channel
     if [[ -n "${FLAGS_download_path}" ]]; then
         download_path="${FLAGS_download_path%%/}"
-    elif [[ "${download_root}" = *flatcar-jenkins* ]]; then
-        if [[ "${download_path}" == gs://* ]]; then
-            download_channel="${download_root##*/}"
-            download_root="gs://${download_channel}.release.flatcar-linux.net"
-        fi
+    elif [[ "${download_root}" == *flatcar-jenkins* ]]; then
+        download_channel="${download_root##*/}"
+        download_root="gs://${download_channel}.release.flatcar-linux.net"
         # Official release download paths don't include the boards directory
         download_path="${download_root%%/}/${BOARD}/${FLATCAR_VERSION}"
     else


### PR DESCRIPTION
`${download_path}` gets initialized only if `${FLAGS_download_path}` is given by the user. If not given, that becomes simply an empty string. So it does not make sense to check if that includes `gs://`. Let's simply remove the if statement.

That's why the vagrant json file still has a wrong URL like `https://flatcar-jenkins/alpha/...`.

Tested with the following test script.

```

download_path=""
download_root="gs://flatcar-jenkins/alpha"

if [[ -n "${FLAGS_download_path}" ]]; then
    download_path="${download_path%%/}"
elif [[ "${download_root}" == *flatcar-jenkins* ]]; then
    download_channel="${download_root##*/}"
    download_root="gs://${download_channel}.release.flatcar-linux.net"
    download_path="${download_root%%/}/amd64-usr/2065.0.0"
else
    download_path="${download_root%%/}/boards/amd64-usr/2065.0.0"
fi

if [[ "${download_path}" == gs://* ]]; then
    download_path="https://${download_path#gs://}"
fi

echo "Result: download_path = ${download_path}"
```