### PR TITLE
build_library: retry losetup up to 10 seconds

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -11,6 +11,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 
 # First sector we can use.
@@ -433,17 +434,23 @@ def FormatFat(part, device):
 def PartitionLoop(options, partition):
   """Allocate (and automatically free) loop devices for a partition."""
 
-  loop_dev = subprocess.check_output(['sudo', 'losetup',
-      '--offset', str(partition['first_byte']),
-      '--sizelimit', str(partition['bytes']),
-      '--find', '--show', options.disk_image])
-  loop_dev = loop_dev.strip()
+  attempts = 0
 
-  try:
-    yield loop_dev
-  finally:
-    Sudo(['losetup', '--detach', loop_dev])
+  while attempts < 10:
+    try:
+      loop_dev = subprocess.check_output(['sudo', 'losetup',
+          '--offset', str(partition['first_byte']),
+          '--sizelimit', str(partition['bytes']),
+          '--find', '--show', options.disk_image])
+      loop_dev = loop_dev.strip()
 
+      yield loop_dev
+
+    except:
+      attempts += 1
+      time.sleep(1)
+    finally:
+      Sudo(['losetup', '--detach', loop_dev])
 
 def FormatPartition(options, part):
   print "Formatting partition %s (%s) as %s" % (


### PR DESCRIPTION
Sometimes we see such failures during Jenkins runs.

```
losetup: /mnt/host/source/tmp/...../disk_image.bin: failed to set up loop device: Resource temporarily unavailable
```

It's really hard to know which race condition it is.

To work around it, in case that losetup fails, make it retry up to 10 seconds, once in every second.
That could reduce the number of the loopback device errors in the build chain.

Inspired by https://chromium-review.googlesource.com/c/chromiumos/platform/crosutils/+/264063/