### PR TITLE
build_torcx_store: bump docker to 18.09

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -238,7 +238,7 @@ function torcx_package() {
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
         =app-torcx/docker-1.12
-        =app-torcx/docker-18.06
+        =app-torcx/docker-18.09
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
To get docker 18.09 included in the edge channel, we need to also update `build_torcx_store`.

It should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/46.