### PR TITLE
remove docker 1.12 17.03 from the torcx store

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -243,7 +243,6 @@ DEFAULT_IMAGES=(
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
-	=app-torcx/docker-18.09
 )
 
 mkdir -p "${BUILD_DIR}"

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -237,14 +237,13 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-1.12
         =app-torcx/docker-18.09
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
-	=app-torcx/docker-17.03
+	=app-torcx/docker-18.09
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
Now that we exclude old versions of Docker, we should exclude Docker 1.12 & 17.03 from the torcx store.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/51.

(For edge)