### PR TITLE
build_torcx_store: get selinux context included in torcx tarballs

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -190,7 +190,7 @@ function torcx_package() {
         fi
 
         tmpfile="${BUILD_DIR}/${name}:${version}.torcx.tgz"
-        tar --force-local -C "${tmppkgroot}" -czf "${tmpfile}" .
+        tar --force-local --selinux --xattrs -C "${tmppkgroot}" -czf "${tmpfile}" .
         sha512sum=$(sha512sum "${tmpfile}" | awk '{print $1}')
 
         # TODO(euank): this opaque digest, if it were reproducible, could save


### PR DESCRIPTION
So far build_torcx_store has not included any selinux context in the tarball, because it ran without `--selinux` option.
Let's add the option to fix that.

This PR should be merged after the PR https://github.com/flatcar-linux/coreos-overlay/pull/55 was merged, and a new Flatcar SDK was released from it.
