### PR TITLE
build_torcx_store: bump docker to 19.03

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -237,7 +237,7 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-18.09
+        =app-torcx/docker-19.03
 )
 
 # This list contains extra images which will be uploaded and included in the


### PR DESCRIPTION
Now that docker was upgraded to 19.03.1, we need to update docker version in `build_torcx_store`.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/62.

_for Flatcar edge_