### PR TITLE
build_library: fix qemu key name to org/flatcar-linux

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -201,7 +201,7 @@ if [ -n "${VM_PFLASH_RO}" ] && [ -n "${VM_PFLASH_RW}" ]; then
 fi
 
 if [ -n "${IGNITION_CONFIG_FILE}" ]; then
-    set -- -fw_cfg name=opt/com.coreos/config,file="${IGNITION_CONFIG_FILE}" "$@"
+    set -- -fw_cfg name=opt/org.flatcar-linux/config,file="${IGNITION_CONFIG_FILE}" "$@"
 fi
 
 case "${VM_BOARD}" in


### PR DESCRIPTION
To fix a wrong key name when running a qemu VM with ignition, we need to replace `opt/com.coreos` with `opt/org.flatcar-linux`.

See also https://github.com/flatcar-linux/ignition/issues/2