### PR TITLE
build_library: remove golang from GLSA whitelist, add polkit

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,10 +4,7 @@
 
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
-	201710-23
-	201803-03
-	201804-12
-	201812-09
+	201908-14 # polkit
 )
 
 glsa_image() {


### PR DESCRIPTION
Since we don't need to rely on old Golang, we can remove Golang-related GLSA entries completely.

Also add a polkit-related GLSA entry, as its security patches are backported.