### PR TITLE
build_library: whitelist 201909-08 for D-BUS

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,6 +5,7 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201908-14 # backported both CVE fixes
+	201909-08 # dbus
 )
 
 glsa_image() {


### PR DESCRIPTION
Since we already backported a security patch to sys-apps/dbus 1.10, we should whitelist GLSA 201909-08 for now.

This PR should be merged together with https://github.com/flatcar-linux/coreos-overlay/pull/74.