### PR TITLE
build_library: whitelist GLSA 201909-01 for perl

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -5,6 +5,7 @@
 GLSA_WHITELIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201908-14 # backported both CVE fixes
+	201909-01 # perl
 	201909-08 # dbus
 )
 


### PR DESCRIPTION
Since we reverted perl to 5.26, we should whitelist 201909-1 for now.