### PR TITLE
setup_board, update_chroot: introduce --binhost= option

### DIFF
--- a/setup_board
+++ b/setup_board
@@ -27,6 +27,8 @@ DEFINE_boolean getbinpkg "${FLAGS_TRUE}" \
   "Download binary packages from remote repository."
 DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
+DEFINE_string binhost "" \
+  "Use binary packages from a specific location (e.g. https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/2000.0.0/pkgs)"
 DEFINE_boolean toolchainpkgonly "${FLAGS_FALSE}" \
   "Use binary packages only for the board toolchain."
 DEFINE_integer jobs "${NUM_JOBS}" \
@@ -159,7 +161,7 @@ BOARD_ETC="${BOARD_ROOT}/etc"
 BOARD_ARCH=$(get_board_arch "$BOARD")
 BOARD_CHOST=$(get_board_chost ${BOARD})
 PORTAGE_PROFILE=$(get_board_profile "$BOARD")
-BOARD_BINHOST=$(generate_binhost_list)
+BOARD_BINHOST="$FLAGS_binhost $(generate_binhost_list)"
 
 if [[ ${FLAGS_regen_configs_only} -eq ${FLAGS_TRUE} ]]; then
   FLAGS_regen_configs=${FLAGS_TRUE}
@@ -197,6 +199,9 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
     UPDATE_ARGS+=" --getbinpkg "
   else
     UPDATE_ARGS+=" --nogetbinpkg "
+  fi
+  if [[ -n "${FLAGS_binhost}" ]]; then
+    UPDATE_ARGS+=" --binhost=${FLAGS_binhost} "
   fi
 else
   UPDATE_ARGS+=" --nousepkg"

--- a/update_chroot
+++ b/update_chroot
@@ -27,6 +27,8 @@ DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update the toolchains."
 DEFINE_string toolchain_boards "" \
   "Extra toolchains to setup for the specified boards."
+DEFINE_string binhost "" \
+  "Use binary packages from a specific location (e.g. https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/2000.0.0/pkgs)"
 
 FLAGS_HELP="usage: $(basename $0) [flags]
 Performs an update of the chroot. This script is called as part of
@@ -57,6 +59,7 @@ PORTAGE_STABLE_OVERLAY="${REPO_ROOT}/src/third_party/portage-stable"
 CROSSDEV_OVERLAY="/usr/local/portage/crossdev"
 COREOS_OVERLAY="${REPO_ROOT}/src/third_party/coreos-overlay"
 COREOS_CONFIG="${COREOS_OVERLAY}/coreos/config"
+PORTAGE_BINHOST="$FLAGS_binhost $(get_sdk_binhost)"
 
 # PORTAGE_USERNAME may already be in the env but set just to be safe.
 : ${PORTAGE_USERNAME:=${USER}}
@@ -83,7 +86,7 @@ PORTDIR_OVERLAY="${CROSSDEV_OVERLAY} ${COREOS_OVERLAY}"
 DISTDIR="${REPO_CACHE_DIR}/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
-PORTAGE_BINHOST="$(get_sdk_binhost)"
+PORTAGE_BINHOST="$PORTAGE_BINHOST"
 PORTAGE_USERNAME="${PORTAGE_USERNAME}"
 MAKEOPTS="--jobs=${NUM_JOBS} --load-average=$((NUM_JOBS * 2))"
 CCACHE_UMASK="002"


### PR DESCRIPTION
Add an option `--binhost=`, to make the scripts download binary packages from any arbitrary URL. The given URL will be then prepended to the list of the default URLs. For example:

```
./setup_board --binhost=https://storage.googleapis.com/flatcar-jenkins/sdk/amd64/2000.0.0/pkgs
```

This is needed to work around toolchain issues when building specific packages especially for ARM64. Though it will be anyway useful for general use cases.