### PR TITLE
build_library: replace coreos with flatcar in disk layout

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -26,7 +26,7 @@
       "3":{
         "label":"USR-A",
         "uuid":"7130c94a-213a-4e5a-8e26-6cce9662f132",
-        "type":"coreos-rootfs",
+        "type":"flatcar-rootfs",
         "blocks":"2097152",
         "fs_blocks":"260094",
         "fs_type":"ext2",
@@ -36,7 +36,7 @@
       "4":{
         "label":"USR-B",
         "uuid":"e03dd35c-7c2d-4a47-b3fe-27f15780a57c",
-        "type":"coreos-rootfs",
+        "type":"flatcar-rootfs",
         "blocks":"2097152",
         "fs_blocks":"262144"
       },
@@ -56,18 +56,18 @@
       },
       "7":{
         "label":"OEM-CONFIG",
-        "type":"coreos-reserved",
+        "type":"flatcar-reserved",
         "blocks":"131072"
       },
       "8":{
         "type":"blank",
-        "label":"coreos-reserved",
+        "label":"flatcar-reserved",
         "blocks":"0"
       },
       "9":{
         "label":"ROOT",
         "fs_label":"ROOT",
-        "type":"coreos-resize",
+        "type":"flatcar-resize",
         "blocks":"4427776",
         "fs_type":"ext4",
         "mount":"/"

--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -400,7 +400,7 @@ def FormatExt(part, device):
   if 'fs_label' in part:
     tune_cmd += ['-L', part['fs_label']]
 
-  if part['type'] == 'coreos-usr':
+  if part['type'] == 'flatcar-usr':
     tune_cmd += ['-U', 'clear',
                  '-T', '20091119110000',
                  '-c', '0', '-i', '0', # Disable auto fsck


### PR DESCRIPTION
To make GPT partition type strings include `flatcar-` strings instead of `coreos-`, we need to change the disk layout file.

This PR should be merged after https://github.com/flatcar-linux/seismograph/pull/1 was merged.