### PR TITLE
build_library: Document when Ignition needs flatcar.first_boot=1, and also document flatcar.autologin

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -21,6 +21,7 @@ SAFE_ARGS=0
 USAGE="Usage: $0 [-a authorized_keys] [--] [qemu options...]
 Options:
     -i FILE     File containing an Ignition config
+                (needs \"-append 'flatcar.first_boot=1'\" for already-booted or PXE images)
     -u FILE     Cloudinit user-data as either a cloud config or script.
     -c FILE     Config drive as an iso or fat filesystem image.
     -a FILE     SSH public keys for login access. [~/.ssh/id_{dsa,rsa}.pub]

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -34,7 +34,8 @@ The -a option may be used to specify a particular ssh public key to give
 login access to. If -a is not provided ~/.ssh/id_{dsa,rsa}.pub is used.
 If no public key is provided or found the VM will still boot but you may
 be unable to login unless you built the image yourself after setting a
-password for the core user with the 'set_shared_user_password.sh' script.
+password for the core user with the 'set_shared_user_password.sh' script
+or provide the option \"-append 'flatcar.autologin'\".
 
 Any arguments after -a and -p will be passed through to qemu, -- may be
 used as an explicit separator. See the qemu(1) man page for more details.


### PR DESCRIPTION
The QEMU boot script has the `-i` option to provide an Ignition configuration.
For PXE images or images that have been booted already, an additional kernel command line parameter is needed for Ignition to work: `flatcar.first_boot=1`. Document this in the usage information of the script.