### PR TITLE
build_library: make toolchain build rust for cross-builds

### DIFF
--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -35,6 +35,11 @@ build_target_toolchain() {
     # --root is required because run_merge overrides ROOT=
     PORTAGE_CONFIGROOT="$ROOT" \
         run_merge -u --root="$ROOT" --sysroot="$ROOT" "${TOOLCHAIN_PKGS[@]}"
+
+    export clst_myemergeopts="$( echo "$clst_myemergeopts" | sed -e 's/--newuse//' )"
+
+    PORTAGE_CONFIGROOT="$ROOT" \
+        run_merge --root="$ROOT" --sysroot="$ROOT" dev-lang/rust
 }
 
 configure_crossdev_overlay / /tmp/crossdev


### PR DESCRIPTION
To make `packages-matrix` build rust sources for `arm64-usr`, we need to make toolchain include the rust target for arm.

Unfortunately, catalyst does not support the cross-build rust target by default.
We also cannot add `dev-lang/rust` to `$TOOLCHAIN_PKGS`, because then catalyst would tries to build a `cross-*/rust` package, which does not exist.

So we need to manually run emerge for rust, without `--newuse -u` options. If the `--newuse -u` options are given, the rust will not be installed at all.