### PR TITLE
jenkins: add ami_vmdk to format list for ARM

### DIFF
--- a/jenkins/formats-arm64-usr.txt
+++ b/jenkins/formats-arm64-usr.txt
@@ -1,3 +1,4 @@
+ami_vmdk
 openstack
 openstack_mini
 packet


### PR DESCRIPTION
The `image-matrix.groovy` script reads the list of image formats for ARM, from `formats-arm64-usr.txt`.

So we need to also add `ami_vmdk` to the list to publish AWS ARM images.