### PR TITLE
build_library: set raid0 default layout to alternate in grub.cfg for stable

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -19,7 +19,7 @@ set randomize_disk_guid=""
 set oem_id=""
 
 # Anything else the OEM adds should use this variable.
-set linux_append=""
+set linux_append="raid0.default_layout=2"
 
 set secure_boot="0"
 


### PR DESCRIPTION
Set the new kernel module parameter for raid0 `default_layout=2` in `grub.cfg`, to make kernel >= 5.4 (and stable kernels) properly load `raid0.ko`. Without the change, raid0 arrays cannot be created at all.
The issue started to appear since https://github.com/torvalds/linux/commit/c84a1372df929033cb1a0441fb57bd3932f39ac9, which is meant to fix a kernel bug that may cause data corruption.

The value for `default_layout` can be 1 (`original`) or 2 (`alternate`). 1 is the orignal layout kernel < 3.14, while 2 is the new layout kernel 3.14. Since kernel 3.14 is already 5 years old, we can probably assume that we do not have to care about migration from raid0 devices that were created by Kernel < 3.14. So simply set it to 2.