### PR TITLE
build_library: fix sync URI under Gentoo env for developer containers

### DIFF
--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -39,12 +39,12 @@ disabled = true
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git
-sync-uri = https://github.com/coreos/coreos-overlay.git
+sync-uri = https://github.com/flatcar-linux/coreos-overlay.git
 
 [portage-stable]
 location = /var/lib/portage/portage-stable
 sync-type = git
-sync-uri = https://github.com/coreos/portage-stable.git
+sync-uri = https://github.com/flatcar-linux/portage-stable.git
 EOF
 
     # Now set the correct profile


### PR DESCRIPTION
When running `emerge-gitclone` in a developer container, it still tries to fetch from coreos repos.
We should make it fetch from flatcar-linux repos.

This PR should be merged together with https://github.com/flatcar-linux/dev-util/pull/1 , https://github.com/flatcar-linux/coreos-overlay/pull/159.