### PR TITLE
build_image: Add prodtar command to build a tar ball

### DIFF
--- a/build_image
+++ b/build_image
@@ -56,12 +56,13 @@ FLAGS_HELP="USAGE: build_image [flags] [list of images to build].
 This script is used to build a CoreOS image. CoreOS comes in many
 different forms.  This scripts can be used to build the following:
 
-prod - Production image for CoreOS. This image is for booting.
+prod - Production image for CoreOS. This image is for booting (default if no argument is given).
+prodtar - Production container tar ball (implies prod). This can e.g. be used to run the Flatcar production image as a container (run machinectl import-tar or docker import).
 container - Developer image with single filesystem, bootable by nspawn.
 
 Examples:
 
-build_image --board=<board> [prod] [container] - builds developer and production images.
+build_image --board=<board> [prod] [prodtar] [container] - builds developer and production images/tars.
 ...
 "
 show_help_if_requested "$@"
@@ -112,10 +113,12 @@ fi
 . "${BUILD_LIBRARY_DIR}/vm_image_util.sh" || exit 1
 
 PROD_IMAGE=0
+PROD_TAR=0
 CONTAINER=0
 for arg in "$@"; do
   case "${arg}" in
     prod) PROD_IMAGE=1 ;;
+    prodtar) PROD_IMAGE=1 PROD_TAR=1 ;;
     container) CONTAINER=1 ;;
     *)    die_notrace "Unknown image type ${arg}" ;;
   esac
@@ -176,6 +179,9 @@ if [[ "${PROD_IMAGE}" -eq 1 ]]; then
     generate_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" ${DISK_LAYOUT}
   elif [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then
     extract_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
+  fi
+  if [[ "${PROD_TAR}" -eq 1 ]]; then
+    create_prod_tar ${FLATCAR_PRODUCTION_IMAGE_NAME}
   fi
 fi
 

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -149,3 +149,20 @@ EOF
   fi
   upload_image -d "${BUILD_DIR}/${image_name}.bz2.DIGESTS" "${to_upload[@]}"
 }
+
+create_prod_tar() {
+  local image_name="$1"
+  local image="${BUILD_DIR}/${image_name}"
+  local container="${BUILD_DIR}/flatcar-container.tar.gz"
+  local lodev="$(sudo losetup --find --show -r -P "${image}")"
+  local lodevbase="$(basename "${lodev}")"
+  sudo mkdir -p "/mnt/${lodevbase}p9"
+  sudo mount "${lodev}p9" "/mnt/${lodevbase}p9"
+  sudo mount "${lodev}p3" "/mnt/${lodevbase}p9/usr"
+  sudo tar --xattrs -czpf "${container}" -C "/mnt/${lodevbase}p9" .
+  sudo umount "/mnt/${lodevbase}p9/usr"
+  sudo umount "/mnt/${lodevbase}p9"
+  sudo rmdir "/mnt/${lodevbase}p9"
+  sudo losetup --detach "${lodev}"
+  upload_image "${container}"
+}

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -73,4 +73,4 @@ script build_image \
     --torcx_manifest=/mnt/host/source/torcx/torcx_manifest.json \
     --torcx_root=/mnt/host/source/torcx/ \
     --upload_root="${UPLOAD_ROOT}" \
-    --upload prod container
+    --upload prodtar container


### PR DESCRIPTION
Create a tar ball with the contents of the / and /usr partitions
to be used as follows with systemd-nspawn (via machinectl):
  machinectl import-tar flatcar-container.tar.gz flatcar-container
  machinectl start flatcar-container
  machinectl shell flatcar-container
or with docker by converting it to an OCI image:
  docker import -c "CMD /bin/bash" flatcar-container.tar.gz flatcar-container

Since the new "prodtar" command relies on the results of the "prod" command,
it bundles it so that "prod prodtar" and "prodtar" is the same.

Note: Document how to use the tars on the website. Automatically push docker images to a repository.