### PR TITLE
[WIP] remove docker 1.12 and 17.03 from torcx store

### DIFF
--- a/build_torcx_store
+++ b/build_torcx_store
@@ -237,14 +237,12 @@ function torcx_package() {
 # for each package will point at the last version specified.  This can handle
 # swapping default package versions for different OS releases by reordering.
 DEFAULT_IMAGES=(
-        =app-torcx/docker-1.12
         =app-torcx/docker-19.03
 )
 
 # This list contains extra images which will be uploaded and included in the
 # generated manifest, but won't be included in the vendor store.
 EXTRA_IMAGES=(
-	=app-torcx/docker-17.03
 )
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
_work-in-progress: please do not merge_

Now that we removed docker 1.12 and 17.03 for Alpha, we need to also remove unnecessary profiles for the torcx store.