### PR TITLE
build_library/vm_image_util.sh: Generate iPXE script

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -768,6 +768,15 @@ You can pass extra kernel parameters with -append, for example:
 When using -nographic or -serial you must also enable the serial console:
   ./$(basename "${script}") -nographic -append 'console=ttyS0,115200n8'
 EOF
+    local packetipxe="$(_dst_dir)/flatcar_production_packet.ipxe"
+    cat > "$packetipxe" <<EOF
+#!ipxe
+
+kernel flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 flatcar.oem.id=packet console=ttyS1,115200n8 flatcar.autologin
+initrd flatcar_production_pxe_image.cpio.gz
+boot
+EOF
+    VM_GENERATED_FILES+=( "$packetipxe" )
 }
 
 _write_iso_conf() {


### PR DESCRIPTION
Write out an iPXE script file for Packet.
    The script uses relative URLs to refer to
    the other PXE files and thus can be copied
    along with the files to any server.
    This is useful because it saves the creation
    of an iPXE script for a release/channel on a
    third-party service. For CI testing it is
    also helpful because the script does not only
    end up on the release server but also already
    on the Google buckets, refering to unpublished
    PXE payloads.

Note: Pick for alpha and edge.