### PR TITLE
build_library/template_vmware.ovf: Remove old CoreOS OVF variables

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -24,34 +24,19 @@
         <Description>Hostname</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.coreos.config.data" ovf:value="">
-        <Label>CoreOS config data (deprecated)</Label>
-        <Description>Inline cloud-config data</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.ignition.config.data" ovf:value="">
         <Label>Ignition config data</Label>
         <Description>Inline Ignition data</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.coreos.config.url" ovf:value="">
-        <Label>CoreOS config url (deprecated)</Label>
-        <Description>URL to cloud-config data</Description>
+                ovf:key="guestinfo.ignition.config.data.encoding" ovf:value="">
+        <Label>Ignition config data encoding</Label>
+        <Description>Encoding for Ignition data (e.g., base64)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.ignition.config.url" ovf:value="">
         <Label>Ignition config url</Label>
         <Description>URL to Ignition data</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.coreos.config.data.encoding" ovf:value="">
-        <Label>CoreOS config data encoding (deprecated)</Label>
-        <Description>Encoding for cloud-config data</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.ignition.config.data.encoding" ovf:value="">
-        <Label>Ignition config data encoding</Label>
-        <Description>Encoding for Ignition data (e.g., base64)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.interface.0.name" ovf:value="">


### PR DESCRIPTION
There was a logical mistake in Ignition that caused ignition.config.*
only to work when it was part of the ovfenv. Thus they were added but
the old CoreOS variables marked deprecated and kept. With both as OVF
variables each of them worked but directly specifying ignition.config.*
as guest variable still didn't because of the logical mistake.
Now there is a fix and both work well when specified directly as guest
variable (https://github.com/flatcar-linux/ignition/pull/11).
Delete the old CoreOS OVF variables because they just clutter the UI
and only the Ignition variables should be used in the UI.

# How to use

First set `380801d9899cceb9edd4b494fa2a9dd8b158c390` as commit in `sys-apps/ignition/ignition-9999.ebuild`.

```
$ emerge-amd64-usr -1 ignition
$ emerge-amd64-usr -1 coreos-kernel
$ ./build_image
$ ./image_to_vm.sh … --format=vmware_ova
```

# Testing done

Tested on ESXi both over the web UI and over `ovftool` for all combinations (no config, `coreos.*` variables, `ignition.*` variables).