### PR TITLE
build_library/template_vmware.ovf: Document and add cloud-init OVF vars

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -25,63 +25,113 @@
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.ignition.config.data" ovf:value="">
-        <Label>Ignition config data</Label>
-        <Description>Inline Ignition data</Description>
+        <Label>Ignition/coreos-cloudinit data</Label>
+        <Description>Inline Ignition config or coreos-cloudinit data (cloud-config or script)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.ignition.config.data.encoding" ovf:value="">
-        <Label>Ignition config data encoding</Label>
-        <Description>Encoding for Ignition data (e.g., base64)</Description>
+        <Label>Ignition/coreos-cloudinit data encoding</Label>
+        <Description>Encoding for Ignition config or coreos-cloudinit data (e.g., base64)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.ignition.config.url" ovf:value="">
-        <Label>Ignition config url</Label>
-        <Description>URL to Ignition data</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.name" ovf:value="">
-        <Label>Name for network interface 0</Label>
-        <Description>Name for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.mac" ovf:value="">
-        <Label>MAC for network interface 0</Label>
-        <Description>MAC for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.dhcp" ovf:value="no">
-        <Label>DHCP support for network interface 0</Label>
-        <Description>DHCP support for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.role" ovf:value="public">
-        <Label>Role for network interface 0</Label>
-        <Description>Role for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.ip.0.address" ovf:value="">
-        <Label>Main IP for network interface 0</Label>
-        <Description>Main IP for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.route.0.gateway" ovf:value="">
-        <Label>Main route gateway for network interface 0</Label>
-        <Description>Main route gateway for network interface 0</Description>
-      </Property>
-      <Property ovf:userConfigurable="true" ovf:type="string"
-                ovf:key="guestinfo.interface.0.route.0.destination" ovf:value="">
-        <Label>Main route destination for network interface 0</Label>
-        <Description>Main route destination for network interface 0</Description>
+        <Label>Ignition/coreos-cloudinit config url</Label>
+        <Description>URL to Ignition config or coreos-cloudinit data (cloud-config or script)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.dns.server.0" ovf:value="">
-        <Label>Primary DNS</Label>
-        <Description>Primary DNS</Description>
+        <Label>Primary DNS (only for coreos-cloudinit)</Label>
+        <Description>Primary DNS (only for coreos-cloudinit)</Description>
       </Property>
       <Property ovf:userConfigurable="true" ovf:type="string"
                 ovf:key="guestinfo.dns.server.1" ovf:value="">
-        <Label>Secondary DNS</Label>
-        <Description>Secondary DNS</Description>
+        <Label>Secondary DNS (only for coreos-cloudinit)</Label>
+        <Description>Secondary DNS (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.name" ovf:value="">
+        <Label>Name for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Name for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.mac" ovf:value="">
+        <Label>MAC for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>MAC for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.dhcp" ovf:value="no">
+        <Label>DHCP support for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>DHCP support for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.role" ovf:value="public">
+        <Label>Role for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Role for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.ip.0.address" ovf:value="">
+        <Label>Main IP for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Main IP for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.ip.1.address" ovf:value="">
+        <Label>Additional IP for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Additional IP for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.route.0.gateway" ovf:value="">
+        <Label>Main route gateway for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Main route gateway for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.route.0.destination" ovf:value="">
+        <Label>Main route destination for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Main route destination for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.route.1.gateway" ovf:value="">
+        <Label>Additional route gateway for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Additional route gateway for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.0.route.1.destination" ovf:value="">
+        <Label>Additional route destination for network interface 0 (only for coreos-cloudinit)</Label>
+        <Description>Additional route destination for network interface 0 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.name" ovf:value="">
+        <Label>Name for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>Name for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.mac" ovf:value="">
+        <Label>MAC for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>MAC for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.dhcp" ovf:value="no">
+        <Label>DHCP support for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>DHCP support for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.role" ovf:value="private">
+        <Label>Role for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>Role for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.ip.0.address" ovf:value="">
+        <Label>Main IP for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>Main IP for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.route.0.gateway" ovf:value="">
+        <Label>Main route gateway for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>Main route gateway for network interface 1 (only for coreos-cloudinit)</Description>
+      </Property>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.interface.1.route.0.destination" ovf:value="">
+        <Label>Main route destination for network interface 1 (only for coreos-cloudinit)</Label>
+        <Description>Main route destination for network interface 1 (only for coreos-cloudinit)</Description>
       </Property>
     </ProductSection>
     <OperatingSystemSection ovf:id="100" vmw:osType="other26xLinux64Guest">


### PR DESCRIPTION
The configuration variables for the Ignition configuration also serve as
data source for coreos-cloudinit config data (which includes plain scripts).
Document them properly and also call out that the networking variables only
work if coreos-cloudinit data is used.
For some use cases, too few networking variables were available. Add secondary
routing variables for the main network interface and add a second interface.

# How to use

The variables are shown in the ESXi web UI or in VMware Workstation Player when a new VM is created from a `.ova` file.

# Testing done

None

Note: Pick for all channels.