### PR TITLE
Reuse correct binary packages for a Flatcar version

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -143,7 +143,7 @@ get_board_binhost() {
     shift
 
     if [[ $# -eq 0 ]]; then
-        set -- "${FLATCAR_SDK_VERSION}" "${FLATCAR_VERSION_ID}"
+        set -- "${FLATCAR_VERSION_ID}"
     fi
 
     for ver in "$@"; do
@@ -172,12 +172,17 @@ get_sdk_libdir() {
 get_sdk_binhost() {
     local arch=$(get_sdk_arch) ver
     if [[ $# -eq 0 ]]; then
-        set -- "${FLATCAR_SDK_VERSION}" "${FLATCAR_VERSION_ID}"
+        set -- "${FLATCAR_SDK_VERSION}"
     fi
 
     for ver in "$@"; do
-        echo "${FLATCAR_DEV_BUILDS}/sdk/${arch}/${ver}/pkgs/"
+        # Usually only crossdev needs to be fetched from /toolchain/ in the setup_board step.
+        # The entry for /pkgs/ is there if something needs to be reinstalled in the SDK
+        # but normally it is not needed because everything is already part of the tarball.
+        # To install the crossdev Rust package, /toolchain-arm64/ is derived from /toolchain/
+        # when necessary in install_cross_toolchain().
         echo "${FLATCAR_DEV_BUILDS}/sdk/${arch}/${ver}/toolchain/"
+        echo "${FLATCAR_DEV_BUILDS}/sdk/${arch}/${ver}/pkgs/"
     done
 }
 
@@ -325,12 +330,12 @@ install_cross_toolchain() {
         $sudo emerge "${emerge_flags[@]}" \
             "cross-${cross_chost}/gdb" "${cross_pkgs[@]}"
         if [ "${cross_chost}" = aarch64-cros-linux-gnu ]; then
-          # Here we need to take only the binary packages from the toolchain builds
+          # Here we need to take only the binary packages from the toolchain-arm64 builds
           # because the standard Rust packages don't include the arm64 cross target.
-          # Building from source is ok because the cross-compiler got installed.
-          FILTERED="$(echo $PORTAGE_BINHOST | tr ' ' '\n' | grep toolchain | xargs echo)"
+          FILTERED="$(echo $PORTAGE_BINHOST | tr ' ' '\n' | grep toolchain | sed 's#toolchain/#toolchain-arm64/#g' | xargs echo)"
           # If no aarch64 folder exists, try to remove any existing Rust packages.
           [ ! -d /usr/lib/rust-*/rustlib/aarch64-unknown-linux-gnu ] && ($sudo emerge -C dev-lang/rust || true)
+          # Building from source is also ok because the cross-compiler got installed.
           $sudo PORTAGE_BINHOST="$FILTERED" emerge "${emerge_flags[@]}" dev-lang/rust
         fi
     fi

--- a/build_toolchains
+++ b/build_toolchains
@@ -43,6 +43,14 @@ sign_and_upload_files "cross toolchain packages" "${def_upload_path}" \
     "toolchain/" "${BINPKGS}/crossdev"/*
 
 for board in $(get_board_list); do
+    if [ "$board" = arm64-usr ]; then
+        sign_and_upload_files "Rust aarch64 crossdev toolchain packages" "${def_upload_path}" \
+            "toolchain-arm64/" "${BINPKGS}/target/${board}"/Packages "${BINPKGS}/target/${board}"/dev-lang/rust*
+    fi
+done
+
+# TODO: Actually just TOOLCHAIN_PKGS and the exact dependencies should be uploaded
+for board in $(get_board_list); do
     board_packages="${BINPKGS}/target/${board}"
     def_upload_path="${UPLOAD_ROOT}/boards/${board}/${FLAGS_version}"
     sign_and_upload_files "board toolchain packages" "${def_upload_path}" \


### PR DESCRIPTION
Two Flatcar versions were used in /etc/portage/make.conf both in the SDK
and in the boards.
Use only a single version by default to get the expected results and not
something else when using binary packages.

The Rust crossdev package was never uploaded to /sdk/ and always
had to be compiled again.
Upload it in a separate directory because /Packages in /crossdev
doesn't refer to the Rust package and its use flags.

# How to use/test

Create a fresh SDK with the last Alpha release manifest. Then enter it and check out this `scripts` branch. Test to build both boards. Only Rust for the arm64 board would be recompiled because it is not uploaded yet to the bucket.

Not tested on Jenkins yet.

Note: Pick for all channels.