### PR TITLE
build_packages: Add flag to ignore some binary packages

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -18,6 +18,8 @@ DEFINE_boolean usepkg "${FLAGS_TRUE}" \
   "Use binary packages when possible."
 DEFINE_boolean usepkgonly "${FLAGS_FALSE}" \
   "Only use/download binary packages. Implies --noworkon"
+DEFINE_string usepkg_exclude "" \
+  "Exclude these binary packages."
 DEFINE_boolean getbinpkg "${FLAGS_TRUE}" \
   "Download binary packages from remote repository."
 DEFINE_string getbinpkgver "" \
@@ -153,6 +155,9 @@ if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]]; then
   fi
   if [[ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]; then
       EMERGE_FLAGS+=( --getbinpkg )
+  fi
+  if [[ -n "${FLAGS_usepkg_exclude}"  ]]; then
+    EMERGE_FLAGS+=("--usepkg-exclude=${FLAGS_usepkg_exclude}")
   fi
 fi
 

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -44,6 +44,7 @@ script setup_board \
 script build_packages \
     --board="${BOARD}" \
     --getbinpkgver=${RELEASE_BASE:-"${FLATCAR_VERSION}" --toolchainpkgonly} \
+    --usepkg_exclude="${BINARY_PACKAGES_TO_EXCLUDE}" \
     --skip_chroot_upgrade \
     --skip_torcx_store \
     --sign="${SIGNING_USER}" \


### PR DESCRIPTION
When the ebuild file changed but not its version nor its cross-workon
commit, the binary package would be used. Also some dependencies are not
encoded to trigger a rebuild of depending packages.
Allow to exclude some binary packages so that we can be sure that they
are rebuilt.

# How to use
In the packages-matrix job in Jenkins or local:
```
./build_packages --usepkg-exclude="package/a package/b"
```

# Testing done

None