### PR TITLE
build_toolchains: Fix upload path for toolchain-arm64 package

### DIFF
--- a/build_toolchains
+++ b/build_toolchains
@@ -45,7 +45,7 @@ sign_and_upload_files "cross toolchain packages" "${def_upload_path}" \
 for board in $(get_board_list); do
     if [ "$board" = arm64-usr ]; then
         sign_and_upload_files "Rust aarch64 crossdev toolchain packages" "${def_upload_path}" \
-            "toolchain-arm64/" "${BINPKGS}/target/${board}"/Packages "${BINPKGS}/target/${board}"/dev-lang/rust*
+            "toolchain-arm64/" "${BINPKGS}/target/${board}"/Packages "${BINPKGS}/target/${board}"/dev-lang
     fi
 done
 


### PR DESCRIPTION
The Rust arm64 crossdev toolchain package was uploaded to
toolchain-arm64/rust… instead of toolchain-arm64/dev-lang/rust….
Upload the complete dev-lang folder as only Rust will be fetched
from there anyway.

# How to use/test
Jenkins test not done yet