### PR TITLE
set_lsb_release: update codename

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -26,7 +26,7 @@ ROOT_FS_DIR="$FLAGS_root"
 [ -d "$ROOT_FS_DIR" ] || die "Root FS does not exist? ($ROOT_FS_DIR)"
 
 OS_NAME="Flatcar Container Linux by Kinvolk"
-OS_CODENAME="Rhyolite"
+OS_CODENAME="Oklo"
 OS_ID="flatcar"
 OS_ID_LIKE="coreos"
 OS_PRETTY_NAME="$OS_NAME $FLATCAR_VERSION (${OS_CODENAME})"


### PR DESCRIPTION
Ported from upstream.

Note: Cherry-pick for all channels and `flatcar-build-2513.0.0`.