### PR TITLE
Extend OEM partition to 200Mb

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -50,7 +50,7 @@
         "label":"OEM",
         "fs_label":"OEM",
         "type":"data",
-        "blocks":"262144",
+        "blocks":"409600",
         "fs_type":"ext4",
         "mount":"/usr/share/oem"
       },


### PR DESCRIPTION
This is needed for the https://github.com/flatcar-linux/coreos-overlay/pull/365

# Extend OEM partition to fit AWS SSM Agent



# How to use

AWS SSM agent disk space usage:

```
builder@localhost /build/amd64-usr/var/tmp/portage/app-emulation/amazon-ssm-agent-2.3.1205.0/image/usr/share/oem/bin $ ls -lh
total 139M
-rwxr-xr-x 1 root root 29M May 19 21:14 amazon-ssm-agent
-rwxr-xr-x 1 root root 24M May 19 21:14 ssm-cli
-rwxr-xr-x 1 root root 28M May 19 21:14 ssm-document-worker
-rwxr-xr-x 1 root root 11M May 19 21:14 ssm-session-logger
-rwxr-xr-x 1 root root 26M May 19 21:14 ssm-session-worker
-rwxr-xr-x 1 root root 24M May 19 21:14 ssm-updater
```
I also found that binaries are stripped already. 

# Testing done

- [x] Build with recent flatcar sdk
