### PR TITLE
Support the /boot/coreos/first_boot flag file

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -69,6 +69,9 @@ fi
 if [ -f "($root)/flatcar/first_boot" ]; then
     set first_boot="flatcar.first_boot=detected"
 fi
+if [ -f "($root)/coreos/first_boot" ]; then
+    set first_boot="flatcar.first_boot=detected"
+fi
 
 # Determine if the disk GUID needs to be randomized.
 search --no-floppy --set randomize_disk_guid \


### PR DESCRIPTION
If a user or old software creates the flag file on the old CoreOS location,
nothing would happen.
Check the old location, too, so that Ignition is rerun.


# How to use

Requires https://github.com/flatcar-linux/bootengine/pull/13 and https://github.com/flatcar-linux/update_engine/pull/5

Build available here:
```
$ wget 'https://storage.googleapis.com/flatcar-jenkins/developer/boards/amd64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu.sh'
$ chmod +x flatcar_production_qemu.sh
$ wget 'https://storage.googleapis.com/flatcar-jenkins/developer/boards/amd64-usr/2345.3.1+dev-flatcar-master-449/flatcar_production_qemu_image.img.bz2'
```

# Testing done

1. Boot up without an Ignition config: `./flatcar_production_qemu.sh`
2. Create the flag file and shutdown via SSH `mkdir /boot/coreos; touch /boot/coreos/first_boot`
3. Boot up with an Ignition config `./flatcar_production_qemu.sh -i someconfig.ign`
4. Check that the config was applied