### PR TITLE
Port CoreOS upstream PRs

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -16,6 +16,7 @@ GLSA_WHITELIST=(
 	202003-30 # fixed by updating within older minor release
 	202003-31 # SDK only
 	202003-52 # difficult to update :-(
+	202004-10 # fixed by updating within older minor release
 	202004-13 # fixed by updating within older minor release
 	202005-02 # SDK only
 	202005-09 # SDK only

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -9,6 +9,13 @@ GLSA_WHITELIST=(
 	201909-01 # Perl, SDK only
 	201909-08 # backported fix
 	201911-01 # package too old to even have the affected USE flag
+	202003-20 # backported fix
+	202003-12 # only applies to old, already-fixed CVEs
+	202003-24 # SDK only
+	202003-26 # SDK only
+	202003-30 # fixed by updating within older minor release
+	202003-31 # SDK only
+	202003-52 # difficult to update :-(
 )
 
 glsa_image() {

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -16,6 +16,9 @@ GLSA_WHITELIST=(
 	202003-30 # fixed by updating within older minor release
 	202003-31 # SDK only
 	202003-52 # difficult to update :-(
+	202004-13 # fixed by updating within older minor release
+	202005-02 # SDK only
+	202005-09 # SDK only
 )
 
 glsa_image() {


### PR DESCRIPTION
Includes https://github.com/coreos/scripts/pull/894 https://github.com/coreos/scripts/pull/893 https://github.com/coreos/scripts/pull/892

Note: For all channels and `flatcar-build-2513.0.0`.