### PR TITLE
Update create-coreos-vdi - grammar change

### DIFF
--- a/contrib/create-coreos-vdi
+++ b/contrib/create-coreos-vdi
@@ -44,7 +44,7 @@ if [ -z "${DEST}" ]; then
 fi
 
 if [[ ! -d "${DEST}" ]]; then
-    echo "$0: Target path (${DEST}) do not exists." >&2
+    echo "$0: Target path (${DEST}) does not exist." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Fixed a grammar based line at `Line 47`:
`echo "$0: Target path (${DEST}) do not exists." >&2` -> `echo "$0: Target path (${DEST}) does not exist." >&2`

# Title: grammar change of error msg
The PR changes a simple line of grammar for the error message you get when creating a template by running this script.

As this is not an actual technical change this change does not require a description imho

# How to use

Not applicable

# Testing done

commands you issued as well as the output you got.]

Tested the script and got a proper reply in the error message (`does not exist` instead of `do not exists`