### PR TITLE
build_library/catalyst: Update virtual/rust during catalyst stage1 for alpha

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -121,6 +121,15 @@ target: stage1
 # stage1 packages aren't published, save in tmp
 pkgcache_path: ${TEMPDIR}/stage1-${ARCH}-packages
 update_seed: yes
+# Install virtual/rust to avoid version conflicts that happen in case of
+# rust versions in the SDK being different from those in the new ebuilds.
+# /usr/share/catalyst/targets/stage1/stage1-chroot.sh installs gcc and
+# its dependencies, including dev-lang/rust, while virtual/rust does not
+# get updated. That results in version conflicts between virtual/rust and
+# dev-lang/rust. To avoid such an issue, we should update virtual/rust
+# before building stage1. Since virtual/rust automatically pulls in
+# dev-lang/rust, we do not need to explicitly specify dev-lang/rust here.
+update_seed_command: --update --deep --newuse --complete-graph --rebuild-if-new-ver gcc virtual/rust
 EOF
 catalyst_stage_default
 }

--- a/build_library/catalyst_toolchains.sh
+++ b/build_library/catalyst_toolchains.sh
@@ -39,7 +39,7 @@ build_target_toolchain() {
     export clst_myemergeopts="$( echo "$clst_myemergeopts" | sed -e 's/--newuse//' )"
 
     PORTAGE_CONFIGROOT="$ROOT" \
-        run_merge --root="$ROOT" --sysroot="$ROOT" dev-lang/rust
+        run_merge --root="$ROOT" --sysroot="$ROOT" virtual/rust
 }
 
 configure_crossdev_overlay / /tmp/crossdev

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -335,9 +335,9 @@ install_cross_toolchain() {
           # because the standard Rust packages don't include the arm64 cross target.
           FILTERED="$(echo $PORTAGE_BINHOST | tr ' ' '\n' | grep toolchain | sed 's#toolchain/#toolchain-arm64/#g' | xargs echo)"
           # If no aarch64 folder exists, try to remove any existing Rust packages.
-          [ ! -d /usr/lib/rust-*/rustlib/aarch64-unknown-linux-gnu ] && ($sudo emerge -C dev-lang/rust || true)
+          [ ! -d /usr/lib/rust-*/rustlib/aarch64-unknown-linux-gnu ] && ($sudo emerge -C virtual/rust dev-lang/rust || true)
           # Building from source is also ok because the cross-compiler got installed.
-          $sudo PORTAGE_BINHOST="$FILTERED" emerge "${emerge_flags[@]}" dev-lang/rust
+          $sudo PORTAGE_BINHOST="$FILTERED" emerge "${emerge_flags[@]}" virtual/rust
         fi
     fi
 


### PR DESCRIPTION
Install `virtual/rust` to avoid version conflicts that happen in case of rust versions in the SDK being different from those in the new ebuilds.

`/usr/share/catalyst/targets/stage1/stage1-chroot.sh` installs gcc and its dependencies, including `dev-lang/rust`, while `virtual/rust` does not get updated. That results in version conflicts between `virtual/rust` and `dev-lang/rust`.

To avoid such an issue, we should update also `virtual/rust` when building stage1. Since `virtual/rust` automatically pulls in `dev-lang/rust`, we do not need to explicitly specify `dev-lang/rust` here.

Also deal with both virtual/rust and dev-lang/rust.
Toolchain utils have installed only `dev-lang/rust`. It could result in version mismatch between `virtual/rust` and `dev-lang/rust`, because `dev-lang/rust` does not automatically pull in `virtual/rust`.
So install `virtual/rust` instead of `dev-lang/rust`.

## How to use

```
sudo FLATCAR_DEV_BUILDS_SDK=https://storage.googleapis.com/flatcar-jenkins/sdk \
  /mnt/host/source/src/scripts/bootstrap_sdk

sudo /mnt/host/source/src/scripts/build_toolchains
```