### PR TITLE
build_library/template_vmware.ovf: Newer OS type and hardware version

### DIFF
--- a/build_library/template_vmware.ovf
+++ b/build_library/template_vmware.ovf
@@ -134,7 +134,7 @@
         <Description>Main route destination for network interface 1 (only for coreos-cloudinit)</Description>
       </Property>
     </ProductSection>
-    <OperatingSystemSection ovf:id="100" vmw:osType="other26xLinux64Guest">
+    <OperatingSystemSection ovf:id="100" vmw:osType="other3xLinux64Guest">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
     <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
@@ -143,7 +143,7 @@
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
         <vssd:InstanceID>0</vssd:InstanceID>
         <vssd:VirtualSystemIdentifier>@@NAME@@</vssd:VirtualSystemIdentifier>
-        <vssd:VirtualSystemType>vmx-11</vssd:VirtualSystemType>
+        <vssd:VirtualSystemType>vmx-13</vssd:VirtualSystemType>
       </System>
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>


### PR DESCRIPTION
The VM hardware and OS type versions were outdated and resulted in
features not being available by default.
Choose a newer ESXi host version (requires 6.5) and set the guest
OS type to Linux 3.x 64 bit.

See https://github.com/flatcar-linux/Flatcar/issues/154

# How to use

Boot a VMware VM in the ESXi web interface or via ovftool/kola or in VMware Player.

# Testing done

Ran kola tests on ESXi and tested manually using the ESXi web interface.