### PR TITLE
common: Support reading the package URL env vars from version.txt

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -264,7 +264,7 @@ load_environment_var() {
   shift
   for name in "$@"; do
     value=$(grep "^${name}=" "${file}" | sed 's|"||g')
-    export "${value}"
+    [[ -n "${value}" ]] && export "${value}"
   done
 }
 
@@ -299,7 +299,8 @@ if [[ -f "${REPO_MANIFESTS_DIR}/version.txt" ]]; then
     FLATCAR_VERSION_ID FLATCAR_SDK_VERSION
   else
     load_environment_var "${REPO_MANIFESTS_DIR}/version.txt" \
-    FLATCAR_VERSION_ID FLATCAR_BUILD_ID FLATCAR_SDK_VERSION
+    FLATCAR_VERSION_ID FLATCAR_BUILD_ID FLATCAR_SDK_VERSION \
+    FLATCAR_DEV_BUILDS FLATCAR_DEV_BUILDS_SDK
     # Don't promote FLATCAR_BUILD_ID into an environment variable when it
     # didn't start as one, since we don't want it leaking into the SDK
     # chroot environment via ENVIRONMENT_WHITELIST.
@@ -309,7 +310,8 @@ if [[ -f "${REPO_MANIFESTS_DIR}/version.txt" ]]; then
 elif [[ -f "${SCRIPT_LOCATION}/version.txt" ]]; then
   # This only happens in update.zip where we must use the current build id.
   load_environment_var "${SCRIPT_LOCATION}/version.txt" \
-      FLATCAR_VERSION_ID FLATCAR_BUILD_ID FLATCAR_SDK_VERSION
+      FLATCAR_VERSION_ID FLATCAR_BUILD_ID FLATCAR_SDK_VERSION \
+      FLATCAR_DEV_BUILDS FLATCAR_DEV_BUILDS_SDK
 else
   die "Unable to locate version.txt"
 fi

--- a/set_version
+++ b/set_version
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEFAULT_BASE_URL="https://storage.googleapis.com/flatcar-jenkins"
+DEV_BOARD_URL="${DEFAULT_BASE_URL}/developer"
+DEV_SDK_URL="${DEFAULT_BASE_URL}/developer/sdk"
+FILE=~/trunk/.repo/manifests/version.txt
+FLATCAR_DEV_BUILDS_SDK=""
+FLATCAR_SDK_VERSION=""
+FLATCAR_DEV_BUILDS=""
+FLATCAR_VERSION=""
+FLATCAR_VERSION_ID=""
+
+# To keep this script usable outside of the SDK chroot, do not include common.sh here.
+
+if [[ $# = 0 ]] || [[ "$1" = "-h" ]] || [[ "$1" = "--help" ]]; then
+  echo "Updates ${FILE} with new values to specify which binary packages to use
+Usage: $0 FLAGS...
+  --board-version (VERSION|BOARD/CHANNEL-nightly): Set FLATCAR_VERSION=VERSION and
+                                                   FLATCAR_VERSION_ID=VERSION where VERSION can
+                                                   be resolved by looking up the latest build
+                                                   referenced by
+                                                   ${DEV_BOARD_URL}/boards/BOARD/CHANNEL-nightly.txt
+  --dev-board:                                     Set FLATCAR_DEV_BUILDS=${DEV_BOARD_URL}
+  --no-dev-board:                                  Remove existing FLATCAR_DEV_BUILDS
+  --sdk-version VERSION:                           Set FLATCAR_SDK_VERSION=VERSION
+  --dev-sdk:                                       Set FLATCAR_DEV_BUILDS_SDK=${DEV_SDK_URL}
+  --no-dev-sdk:                                    Remove existing FLATCAR_DEV_BUILDS_SDK
+  --file FILE:                                     Modify another file than ${FILE}, useful if run
+                                                   outside of the SDK chroot. If /dev/stdout or
+                                                   /dev/stderr is used, only new values are printed.
+"
+  exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+  ARG="$1"
+  shift
+  case "${ARG}" in
+    --board-version)
+      VAL="$1"
+      shift
+      if [[ "${VAL}" == */*-nightly ]]; then
+        VAL=$(curl -s -S -f -L "${DEV_BOARD_URL}/boards/${VAL}.txt")
+      fi
+      FLATCAR_VERSION="${VAL}"
+      FLATCAR_VERSION_ID="${VAL}"
+      ;;
+    --dev-board)
+      FLATCAR_DEV_BUILDS="${DEV_BOARD_URL}"
+      ;;
+    --no-dev-board)
+      FLATCAR_DEV_BUILDS=no
+      ;;
+    --sdk-version)
+      FLATCAR_SDK_VERSION="$1"
+      shift
+      ;;
+    --dev-sdk)
+      FLATCAR_DEV_BUILDS_SDK="${DEV_SDK_URL}"
+      ;;
+    --no-dev-sdk)
+      FLATCAR_DEV_BUILDS_SDK=no
+      ;;
+    --file)
+      FILE="$1"
+      shift
+      ;;
+    *)
+      echo "Unkown argument ${ARG}"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "${FILE}" != "/dev/stdout" ]] && [[ "${FILE}" != "/dev/stderr" ]]; then
+  [[ -n "${FLATCAR_VERSION}" ]] && sed -i "/FLATCAR_VERSION=.*/d" "${FILE}"
+  [[ -n "${FLATCAR_VERSION_ID}" ]] && sed -i "/FLATCAR_VERSION_ID=.*/d" "${FILE}"
+  [[ -n "${FLATCAR_DEV_BUILDS}" ]] && sed -i "/FLATCAR_DEV_BUILDS=.*/d" "${FILE}"
+  [[ -n "${FLATCAR_SDK_VERSION}" ]] && sed -i "/FLATCAR_SDK_VERSION=.*/d" "${FILE}"
+  [[ -n "${FLATCAR_DEV_BUILDS_SDK}" ]] && sed -i "/FLATCAR_DEV_BUILDS_SDK=.*/d" "${FILE}"
+fi
+
+{
+  [[ -n "${FLATCAR_VERSION}" ]] && echo "FLATCAR_VERSION=${FLATCAR_VERSION}"
+  [[ -n "${FLATCAR_VERSION_ID}" ]] && echo "FLATCAR_VERSION_ID=${FLATCAR_VERSION_ID}"
+  [[ -n "${FLATCAR_DEV_BUILDS}" ]] && [[ "${FLATCAR_DEV_BUILDS}" != no ]] && echo "FLATCAR_DEV_BUILDS=${FLATCAR_DEV_BUILDS}"
+  [[ -n "${FLATCAR_SDK_VERSION}" ]] && echo "FLATCAR_SDK_VERSION=${FLATCAR_SDK_VERSION}"
+  [[ -n "${FLATCAR_DEV_BUILDS_SDK}" ]] && [[ "${FLATCAR_DEV_BUILDS_SDK}" != no ]] && echo "FLATCAR_DEV_BUILDS_SDK=${FLATCAR_DEV_BUILDS_SDK}"
+} >> "${FILE}"


### PR DESCRIPTION
The environment variables FLATCAR_DEV_BUILDS and FLATCAR_DEV_BUILDS_SDK
define where the base URL for the binary package store of the board
packages and the SDK packages. To set it, they were either exported in
the chroot or passed each time as parameter but this was only available
for the SDK packages in the tricky order
"update_chroot --dev_builds_sdk URL" (or --binhost) and then
"./build_packages --skip_chroot_upgrade".
The defining information for binary package URL comes from version.txt
but it lacks the base URL for a convenient use. Add the base URLs for
SDK and board packages there to be able to get binary packages without
manual tricks and errors. Any changes to
~/trunk/.repo/manifests/version.txt will directly be picked up
from ./build_packages and friends to set the correct URLs in
/etc/portage/make.conf and /build/BOARD/etc/portage/make.conf
so that even a manual "emerge(-BOARD) --usepkg --getbinpkg" uses them.
A helper script "./set_version" is provided to ease modifying
~/trunk/.repo/manifests/version.txt by resolving the latest nightly
version.
Later this functionality can also be used to simplify the Jenkins code
which currently sets these variables (but the special case of the
Release Base download being different from the upload holds).

# How to use

```
cork enter
./set_version --dev-board --board-version amd64-usr/stable-nightly
./build_packages
```


# Testing done

I tested that building an image with the local SDK uses the correct binary package URLs (emerge downloads them) and that the script modifies the files correctly.