### PR TITLE
Stop probing for UUID 00000000-0000-0000-0000-000000000001 in GRUB

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -73,13 +73,6 @@ if [ -f "($root)/coreos/first_boot" ]; then
     set first_boot="flatcar.first_boot=detected"
 fi
 
-# Determine if the disk GUID needs to be randomized.
-search --no-floppy --set randomize_disk_guid \
-       --disk-uuid 00000000-0000-0000-0000-000000000001
-if [ -n "$randomize_disk_guid" ]; then
-    set randomize_disk_guid="flatcar.randomize_disk_guid=00000000-0000-0000-0000-000000000001"
-fi
-
 set oem=""
 if [ -n "$oem_id" ]; then
     set oem="flatcar.oem.id=$oem_id"


### PR DESCRIPTION
# Stop probing for UUID 0x01 in GRUB

Our GRUB configuration is currently probing all devices in search of a device with UUID 00000000-0000-0000-0000-000000000001. This is causing trouble on Packet c3.medium.x86 and m2.xlarge.x86 machines, where this probing leads to the machine hanging on GRUB for almost half an hour and then not mounting the disks correctly. See flatcar-linux/Flatcar#155 for more information.

This code removes the probing from GRUB. An equivalent check will be added to bootengine to be performed during initramfs.

# How to use / Testing done

Building an image with this change leads to GRUB booting successfully on a c3.medium.x86 machine.  Without the corresponding bootengine change, the disk UUID stays at 0x01. With the corresponding change, it gets randomized after initramfs is done running.

WIP notice: Due to issues with current flatcar-master-alpha, I wasn't yet able to fully test this change on all platforms, I only manually tested it on Packet. Once alpha is fixed, I'll test again on all platforms.