### PR TITLE
build_library/catalyst.sh: Specify which gcc package to rebuild

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -129,7 +129,7 @@ update_seed: yes
 # dev-lang/rust. To avoid such an issue, we should update virtual/rust
 # before building stage1. Since virtual/rust automatically pulls in
 # dev-lang/rust, we do not need to explicitly specify dev-lang/rust here.
-update_seed_command: --update --deep --newuse --complete-graph --rebuild-if-new-ver gcc virtual/rust
+update_seed_command: --update --deep --newuse --complete-graph --rebuild-if-new-ver --rebuild-exclude cross-*-cros-linux-gnu/* sys-devel/gcc virtual/rust
 EOF
 catalyst_stage_default
 }


### PR DESCRIPTION
The default update seed command does only specify gcc which leads to
an error because »The short ebuild name "gcc" is ambiguous«.
Choose the standard package name instead of the cross compiler packages
under the assumption that it doesn't really matter at this point, but
if needed we can add the other package names later, too.


# How to use

Run the manifest job with `sdk-full` as downstream.

# Testing done

The failing part now succeeded but the build failed due to other issues.