### PR TITLE
build_library/toolchain_util.sh: Remove old download code for Rust

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -332,14 +332,13 @@ install_cross_toolchain() {
         echo "Installing existing binaries"
         $sudo emerge "${emerge_flags[@]}" \
             "cross-${cross_chost}/gdb" "${cross_pkgs[@]}"
-        if [ "${cross_chost}" = aarch64-cros-linux-gnu ]; then
-          # Here we need to take only the binary packages from the toolchain-arm64 builds
-          # because the standard Rust packages don't include the arm64 cross target.
-          FILTERED="$(echo $PORTAGE_BINHOST | tr ' ' '\n' | grep toolchain | sed 's#toolchain/#toolchain-arm64/#g' | xargs echo)"
-          # If no aarch64 folder exists, try to remove any existing Rust packages.
-          [ ! -d /usr/lib/rust-*/rustlib/aarch64-unknown-linux-gnu ] && ($sudo emerge -C virtual/rust dev-lang/rust || true)
-          # Building from source is also ok because the cross-compiler got installed.
-          $sudo PORTAGE_BINHOST="$FILTERED" emerge "${emerge_flags[@]}" virtual/rust
+        if [ "${cross_chost}" = aarch64-cros-linux-gnu ] && \
+           [ ! -d /usr/lib64/rust-*/rustlib/aarch64-unknown-linux-gnu ] && [ ! -d /usr/lib64/rustlib/aarch64-unknown-linux-gnu ]; then
+          # If no aarch64 folder exists, warn about the situation but don't compile Rust here or download it as binary package
+          echo "WARNING: No aarch64 cross-compilation Rust libraries found!"
+          echo "In case building fails, make sure the old Rust version is deleted with: sudo emerge -C virtual/rust dev-lang/rust"
+          echo "Then install it again with: sudo emerge "${emerge_flags[@]}" virtual/rust"
+          echo "This will download the binary package or build from source."
         fi
     fi
 


### PR DESCRIPTION
The SDK now includes a Rust version with the aarch64 cross-compilation
libraries and the toolchain job doesn't build it anymore. Yet it was 
still recompiled because the path had changed.
Remove the adjustment of the download URL and any automatic building
of Rust. Just issue a warning so that any problem can be spotted easily.
This change does not affect the SDK bootstrapping (full or just stage4)
but affects ./build_packages and the toolchains job. For the toolchains
job the crossdev setup is missing anyway and rebuilding wouldn't help
but only downloading, yet since in stage4 there are no binary package
URLs at all, it's best to remove this step and if it is needed later,
the warning will help.

# How to use
Build the toolchains job with a new SDK and see that no Rust recompilation happens.

# Testing done
[Tested building](http://localhost:9091/job/os/job/manifest/695/parameters/) with an SDK that has an old Rust version and always updates it.
[Tested building](http://localhost:9091/job/os/job/manifest/696/parameters/) with an SDK that has a recent Rust version and doesn't update it by itself.