### PR TITLE
build_library: cgroupv2 only

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -19,7 +19,7 @@ set randomize_disk_guid=""
 set oem_id=""
 
 # Anything else the OEM adds should use this variable.
-set linux_append="systemd.unified_cgroup_hierarchy=false systemd.legacy_systemd_cgroup_controller=false"
+set linux_append="systemd.unified_cgroup_hierarchy=true"
 
 set secure_boot="0"
 


### PR DESCRIPTION
# build_library: cgroupv2 only

currently [edge] has cgroup v2 available via hybrid hierarchy, which is
_fine_, but that is not the goal. Testing a real next step for linux
will be to run unified hierarchy _only_.

This will certainly not work for all container runtimes currently, but
having access to the default behavior is needed for better testing and
exposure.

Signed-off-by: Vincent Batts <vbatts@kinvolk.io>

# How to use

you can currently already test the behaviour of this today by adding this kernel parameter. 
In `/usr/share/oem/grub.cfg`:
```
set linux_append="systemd.unified_cgroup_hierarchy=true"
```
and reboot your flatcar host. Then poke around for what breaks and which upstream project to file issues with or get their newer release.

# Testing done

tested that the image builds and runs. 

Granted, things like `docker` don't currently work, but that is part of the upstream testing and feedback needed.
