### PR TITLE
Add Azure Pro to the list of amd64 format list

### DIFF
--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -1,6 +1,7 @@
 ami
 ami_vmdk
 azure
+azure_pro
 gce
 iso
 pxe


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan@kinvolk.io>

# Add Azure Pro to the list of amd64 format list


# How to use

Trigger a Jenkins build and let it should automatically pick Azure Pro 


# Testing done

None done yet.
