### PR TITLE
jenkins: do not configure ccache variables

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -236,12 +236,9 @@ catalyst_init() {
 }
 
 write_configs() {
-    # No catalyst config option, so defined via environment
-    export CCACHE_DIR="$TEMPDIR/ccache"
-
     info "Creating output directories..."
-    mkdir -m 775 -p "$TEMPDIR/portage/repos.conf" "$DISTDIR" "$CCACHE_DIR"
-    chown portage:portage "$DISTDIR" "$CCACHE_DIR"
+    mkdir -m 775 -p "$TEMPDIR/portage/repos.conf" "$DISTDIR"
+    chown portage:portage "$DISTDIR"
     info "Writing out catalyst configs..."
     info "    catalyst.conf"
     catalyst_conf > "$TEMPDIR/catalyst.conf"

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -344,7 +344,6 @@ install_cross_toolchain() {
 
     # Setup environment and wrappers for our shiny new toolchain
     gcc_set_latest_profile "${cross_chost}"
-    $sudo CC_QUIET=1 ccache-config --install-links "${cross_chost}"
     $sudo CC_QUIET=1 sysroot-config --install-links "${cross_chost}"
 }
 

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -ex
 
-# Use a ccache dir that persists across SDK recreations.
-# XXX: alternatively use a ccache dir that is usable by all jobs on a given node.
-mkdir -p ccache
-
 enter() {
         local verify_key=
         trap 'sudo rm -f chroot/etc/portage/gangue.*' RETURN
@@ -13,8 +9,6 @@ enter() {
         sudo ln -f "${GOOGLE_APPLICATION_CREDENTIALS}" \
             chroot/etc/portage/gangue.json
         bin/cork enter --bind-gpg-agent=false -- env \
-            CCACHE_DIR=/mnt/host/source/ccache \
-            CCACHE_MAXSIZE=5G \
             FLATCAR_DEV_BUILDS="${DOWNLOAD_ROOT}" \
             FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \
             {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \
@@ -32,9 +26,6 @@ export FLATCAR_BUILD_ID
 
 # Set up GPG for signing uploads.
 gpg --import "${GPG_SECRET_KEY_FILE}"
-
-# Figure out if ccache is doing us any good in this scheme.
-enter ccache --zero-stats
 
 script setup_board \
     --board="${BOARD}" \
@@ -61,5 +52,3 @@ script build_torcx_store \
     --torcx_upload_root="${TORCX_PKG_DOWNLOAD_ROOT}" \
     --tectonic_torcx_download_root="${TECTONIC_TORCX_DOWNLOAD_ROOT}" \
     --upload
-
-enter ccache --show-stats

--- a/update_chroot
+++ b/update_chroot
@@ -71,7 +71,7 @@ PORTAGE_BINHOST="$FLAGS_binhost $(get_sdk_binhost)"
 : ${PORTAGE_USERNAME:=${USER}}
 
 # Clean up old distfiles cache. It used to be split for 'host' and
-# 'target' but that just duplicates files. Also a ccache was in there.
+# 'target' but that just duplicates files.
 if [[ -d "${REPO_CACHE_DIR}/distfiles/host" ]]; then
   info "Cleaning up old distfiles cache..."
   sudo mv "${REPO_CACHE_DIR}"/{distfiles/host,distfiles.host}
@@ -95,7 +95,6 @@ PORT_LOGDIR="/var/log/portage"
 PORTAGE_BINHOST="$PORTAGE_BINHOST"
 PORTAGE_USERNAME="${PORTAGE_USERNAME}"
 MAKEOPTS="--jobs=${NUM_JOBS} --load-average=$((NUM_JOBS * 2))"
-CCACHE_UMASK="002"
 
 # Generally there isn't any need to add packages to @world by default.
 # You can use --select to override this.
@@ -214,7 +213,6 @@ EMERGE_CMD="emerge"
 # can cause serious issues later.
 info "Updating basic system packages"
 sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" \
-    dev-util/ccache \
     sys-apps/portage \
     sys-devel/crossdev \
     sys-devel/sysroot-wrappers \


### PR DESCRIPTION
Setting the invalid `CCACHE_` variables resulted in strange failure in projects depending on meson, newer version like 0.55.3.
For example systemd build fails like the following errors:

```
 * ACCESS DENIED:  utimes:       /mnt/host/source/ccache
 * ACCESS DENIED:  utimes:       /mnt/host/source/ccache

F: utimes
S: deny
P: /mnt/host/source/ccache
A: /mnt/host/source/ccache
R: /mnt/host/source/ccache
C: ccache cc /build/amd64-usr/var/tmp/portage/sys-apps/systemd-246/work/systemd-246-abi_x86_64.amd64/meson-private/sanitycheckc.c -o /build/amd64-usr/var/tmp/portage/sys-apps/systemd-246/work/systemd-246-abi_x86_64.amd64/meson-private/sanitycheckc.exe -O1 -pipe -pipe -D_FILE_OFFSET_BITS=64
```

We should not set up ccache at all, as it has been already disabled in coreos-overlay repo.

## Testing done

CI passed