### PR TITLE
Python transition: add a way to remove hard blockers and default to python3 interpreter

### DIFF
--- a/build_library/catalyst_sdk.sh
+++ b/build_library/catalyst_sdk.sh
@@ -7,8 +7,8 @@ source /tmp/toolchain_util.sh
 echo "Double checking everything is fresh and happy."
 run_merge -uDN --with-bdeps=y world
 
-echo "Setting the default Python interpreter to Python 3."
-eselect python set python3.9
+echo "Setting the default Python interpreter"
+eselect python update
 
 echo "Building cross toolchain for the SDK."
 configure_crossdev_overlay / /tmp/crossdev

--- a/build_library/catalyst_sdk.sh
+++ b/build_library/catalyst_sdk.sh
@@ -7,8 +7,8 @@ source /tmp/toolchain_util.sh
 echo "Double checking everything is fresh and happy."
 run_merge -uDN --with-bdeps=y world
 
-echo "Setting the default Python interpreter to Python 2."
-eselect python set python2.7
+echo "Setting the default Python interpreter to Python 3."
+eselect python set python3.9
 
 echo "Building cross toolchain for the SDK."
 configure_crossdev_overlay / /tmp/crossdev

--- a/build_library/update_chroot_util.sh
+++ b/build_library/update_chroot_util.sh
@@ -1,0 +1,62 @@
+# Copyright © Microsoft Corporation
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+get_versions_from_equery() {
+    local equery_cmd="${1}"
+    local pkg="${2}"
+
+    "${equery_cmd}" --quiet --no-color list --format='${version} ${fullversion}' "${pkg}"
+}
+
+filter_out_too_new() {
+    local version="${1}"
+    local line
+    local other
+    local otherfull
+    local result
+
+    while read -r line; do
+        other=$(echo "${line}" | cut -d' ' -f1)
+        otherfull=$(echo "${line}" | cut -d' ' -f2)
+        result=$(printf '%s\n%s\n' "${version}" "${other}" | sort --version-sort | head --lines 1)
+        if [[ "${result}" != "${version}" ]]; then
+            echo "${otherfull}"
+        fi
+    done
+}
+
+# Remove hard blocks using passed emerge and equery commands, and a
+# list of packages to be dropped. A package is specified as full
+# package name and a version, separated by a colon. All packages with
+# this name and with a lower version will be forcibly removed.
+#
+# Example invocation:
+#
+# $ remove_hard_blocks \
+#       emerge-amd64-usr equery-amd64-usr \
+#       dev-python/setuptools_scm:2
+remove_hard_blocks() {
+    local emerge_cmd="${1}"
+    local equery_cmd="${2}"
+    local pkg_ver
+    local line
+    local pkg
+    local version
+    local -a pkgs_to_drop
+    shift 2
+
+    for pkg_ver; do
+        pkg=$(echo "${pkg_ver}" | cut -d: -f1)
+        version=$(echo "${pkg_ver}" | cut -d: -f2)
+        while read -r line; do
+            pkgs_to_drop+=("${pkg}-${line}")
+        done < <(get_versions_from_equery "${equery_cmd}" "${pkg}" | filter_out_too_new "${version}")
+    done
+    if [[ ${#pkgs_to_drop[@]} -gt 0 ]]; then
+        info "Dropping the following packages to avoid hard blocks: ${pkgs_to_drop[@]}"
+        "${emerge_cmd}" -C "${pkgs_to_drop[@]}"
+    else
+        info "No hard blockers to remove"
+    fi
+}

--- a/changelog/changes/2021-12-10-python-update.md
+++ b/changelog/changes/2021-12-10-python-update.md
@@ -1,0 +1,2 @@
+- Rework the way we set up the default python intepreter in SDK - it is now without specifying a version. This should work fine as long as we keep having one version of python in SDK.
+- Add a way to remove packages that are hard-blockers for update. A hard-blocker means that the package needs to be removed (for example with `emerge -C`) before an update can happen.

--- a/update_chroot
+++ b/update_chroot
@@ -7,6 +7,7 @@
 
 . "$(dirname "$0")/common.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/toolchain_util.sh"
+. "${BUILD_LIBRARY_DIR}/update_chroot_util.sh"
 
 # Script must run inside the chroot
 assert_inside_chroot "$@"
@@ -241,6 +242,17 @@ if [ "${FLAGS_workon}" -eq "${FLAGS_TRUE}" ]; then
     EMERGE_FLAGS+=( "--reinstall-atoms=${pkg}" "--usepkg-exclude=${pkg}" )
   done
 fi
+
+sudo_e_emerge() {
+    sudo -E "${EMERGE_CMD}" "${@}"
+}
+
+info "Maybe removing some hard blocks"
+# dev-python/setuptools_scm: blocks the update of the package (newer
+# versions have !!<dev-python/setuptools_scm-2 in BDEPEND).
+remove_hard_blocks \
+    sudo_e_emerge equery \
+    dev-python/setuptools_scm:2
 
 # Second pass, update everything else.
 EMERGE_FLAGS+=( --deep )


### PR DESCRIPTION
And set it to remove some old version of dev-python/setuptools_scm
package.

Also sets the default python interpreter to python3.

This should be merged together with with https://github.com/flatcar-linux/portage-stable/pull/214 and https://github.com/flatcar-linux/coreos-overlay/pull/1277.

CI: http://localhost:9091/job/os/job/manifest/4229/cldsv/