### PR TITLE
build_library: Ignore more categories in write_licenses

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -368,10 +368,12 @@ write_licenses() {
 
     local pkg pkg_sep
     for pkg in $(image_packages "$1" | sort); do
-        # Ignore virtual packages since they aren't licensed
-        if [[ "${pkg%%/*}" == "virtual" ]]; then
-            continue
-        fi
+        # Ignore certain categories of packages since they aren't licensed
+        case "${pkg%%/*}" in
+            'virtual'|'acct-group'|'acct-user')
+                continue
+                ;;
+        esac
 
         local lic_str="$(get_metadata "$1" "${pkg}" LICENSE)"
         if [[ -z "$lic_str" ]]; then


### PR DESCRIPTION
acct-user and acct-group categories aren't licensed too.

CI: http://localhost:9091/job/os/job/manifest/3693/cldsv/