### PR TITLE
Fix the traps to align with bash 5.1 upgrade

### DIFF
--- a/build_library/board_options.sh
+++ b/build_library/board_options.sh
@@ -29,7 +29,7 @@ pkg_use_enabled() {
 # Prints: some-pkg/name-1.2.3
 # Note: returns 0 even if the package was not found.
 pkg_version() {
-  portageq-"${BOARD}" best_visible "${BOARD_ROOT}" "$1" "$2"
+  portageq-"${BOARD}" best_visible "${BOARD_ROOT}" "$1" "$2" || :
 }
 
 # Usage: pkg_provides [installed|binary] some-pkg/name-1.2.3

--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -124,13 +124,16 @@ sign_and_upload_files() {
     local suffix="$3"
     shift 3
 
+    # run a subshell to possibly clean the temporary directory with
+    # signatures without clobbering the global EXIT trap
+    (
     # Create simple GPG detached signature for all uploads.
     local sigs=()
     if [[ -n "${FLAGS_sign}" ]]; then
         local file
         local sigfile
         local sigdir=$(mktemp --directory)
-        trap "rm -rf ${sigdir}" RETURN
+        trap "rm -rf ${sigdir}" EXIT
         for file in "$@"; do
             if [[ "${file}" =~ \.(asc|gpg|sig)$ ]]; then
                 continue
@@ -150,6 +153,7 @@ sign_and_upload_files() {
     fi
 
     upload_files "${msg}" "${path}" "${suffix}" "$@" "${sigs[@]}"
+    )
 }
 
 upload_packages() {

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -114,13 +114,16 @@ function torcx_package() {
         local name=${name##*/}
         local version=${version%%-r*}
 
+        # Run in a subshell to clean tmproot and tmppkgroot up without
+        # clobbering this shell's EXIT trap.
+        (
         # Set up the base package layout to dump everything into /bin and /lib.
         # tmproot is what the packages are installed into.
         # A subset of the files from tmproot are then moved into tmppkgroot,
         # which is then archived and uploaded.
         tmproot=$(sudo mktemp --tmpdir="${BUILD_DIR}" -d)
         tmppkgroot=$(sudo mktemp --tmpdir="${BUILD_DIR}" -d)
-        trap "sudo rm -rf '${tmproot}' '${tmppkgroot}'" EXIT RETURN
+        trap "sudo rm -rf '${tmproot}' '${tmppkgroot}'" EXIT
         sudo chmod 0755 "${tmproot}" "${tmppkgroot}"
         sudo mkdir -p "${tmproot}"/{.torcx,bin,lib,usr}
         sudo ln -fns ../bin "${tmproot}/usr/bin"
@@ -228,8 +231,7 @@ function torcx_package() {
             "${source_pkg}" \
             "${update_default}" \
             "${pkg_locations[@]}"
-
-        trap - EXIT
+        )
 }
 
 # This list defines every torcx image that goes into the vendor store for the

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -178,10 +178,11 @@ function torcx_package() {
         find -H "${tmproot}"/{bin,lib} -type f |
         while read file
         do
+                (
                 rpath=$(sudo patchelf --print-rpath "${file}" 2>/dev/null) &&
                 test "${rpath#/ORIGIN/}" != "${rpath}" &&
                 sudo patchelf --set-rpath "${rpath/#?/\$}" "${file}"
-                :  # Set $? to 0 or the pipeline fails and -e quits.
+                ) || :  # Set $? to 0 or the pipeline fails and -e quits.
         done
 
         # Move anything we plan to package to its root.

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -108,7 +108,7 @@ function torcx_package() {
         local version=${pkg:${#name}+1}
         local manifest_path="${2}"
         local type="${3}"
-        local deppkg digest file rpath sha512sum source_pkg rdepends tmproot tmppkgroot update_default
+        local deppkg digest file rpath sha512sum source_pkg rdepends tmproot tmppkgroot update_default tmpfile
         local pkg_cas_file pkg_cas_root
         local pkg_locations=()
         local name=${name##*/}

--- a/common.sh
+++ b/common.sh
@@ -979,8 +979,8 @@ fixup_liblto_softlinks() {
   local link
   local target
   # check both native (/usr/CHOST/) as well as cross compile (/usr/CHOST/CTARGET) paths
-  { ls -l "${root}/"usr/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so 2>/dev/null;
-    ls -l "${root}/"usr/*/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so 2>/dev/null; } \
+  { ls -l "${root}/"usr/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so 2>/dev/null || :;
+    ls -l "${root}/"usr/*/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so 2>/dev/null || :; } \
     | sed 's:.* \([^[:space:]]\+\) -> \([^[:space:]]\+\):\1 \2:' \
     | while read link target; do
               local newtarget=$(echo "$target" | sed "s:${root}:/:")

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -43,7 +43,10 @@ sudo rm -rf chroot/build src/build torcx
 
 enter() {
         local verify_key=
-        trap 'sudo rm -f chroot/etc/portage/gangue.*' RETURN
+        # Run in a subshell to clean some gangue files on exit without
+        # possibly clobbering the global EXIT trap.
+        (
+        trap 'sudo rm -f chroot/etc/portage/gangue.*' EXIT
         [ -s verify.asc ] &&
         sudo ln -f verify.asc chroot/etc/portage/gangue.asc &&
         verify_key=--verify-key=/etc/portage/gangue.asc
@@ -55,6 +58,7 @@ enter() {
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"
+        )
 }
 
 script() {

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -47,7 +47,10 @@ bin/cork update \
 
 enter() {
         local verify_key=
-        trap 'sudo rm -f chroot/etc/portage/gangue.*' RETURN
+        # Run in a subshell to clean some gangue files on exit without
+        # possibly clobbering the global EXIT trap.
+        (
+        trap 'sudo rm -f chroot/etc/portage/gangue.*' EXIT
         [ -s verify.asc ] &&
         sudo ln -f verify.asc chroot/etc/portage/gangue.asc &&
         verify_key=--verify-key=/etc/portage/gangue.asc
@@ -60,6 +63,7 @@ enter() {
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"
+        )
 }
 
 script() {

--- a/jenkins/vms.sh
+++ b/jenkins/vms.sh
@@ -43,7 +43,10 @@ sudo rm -rf chroot/build tmp
 
 enter() {
         local verify_key=
-        trap 'sudo rm -f chroot/etc/portage/gangue.*' RETURN
+        # Run in a subshell to clean some gangue files on exit without
+        # possibly clobbering the global EXIT trap.
+        (
+        trap 'sudo rm -f chroot/etc/portage/gangue.*' EXIT
         [ -s verify.asc ] &&
         sudo ln -f verify.asc chroot/etc/portage/gangue.asc &&
         verify_key=--verify-key=/etc/portage/gangue.asc
@@ -55,6 +58,7 @@ enter() {
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"
+        )
 }
 
 script() {


### PR DESCRIPTION
# Fix the traps to align with bash 5.1 upgrade

With the migration to bash 5.1, RETURN traps have been not functioning ideally. This PR majorly focuses on fixing those traps by emulating the same with EXIT trap inside a subshell.

## How to use
```
emerge-amd64-usr app-shells/bash
```

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3686/cldsv/

To be merged with https://github.com/flatcar-linux/coreos-overlay/pull/1313