### PR TITLE
jenkins/kola/packet.sh: fix check for skipping machine type tests

### DIFF
--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -31,9 +31,9 @@ if [[ "${KOLA_TESTS}" == "" ]]; then
   KOLA_TESTS="*"
 fi
 
-# cl.basic includes cl.internet which is run on multiple instance types
-cl_basic_included="$(bin/kola list --platform=packet --filter "${KOLA_TESTS}" | grep cl.basic)"
-if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_basic_included}" != ""  ]]; then
+# Run the cl.internet test on multiple machine types only if it should run in general
+cl_internet_included="$(set -o noglob; bin/kola list --platform=packet --filter ${KOLA_TESTS} | { grep cl.internet || true ; } )"
+if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_internet_included}" != ""  ]]; then
   for INSTANCE in c3.small.x86 c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
     (
     OUTPUT=$(timeout --signal=SIGQUIT "${timeout}" bin/kola run \


### PR DESCRIPTION
The cl.basic and cl.internet tests are different tests which wasn't
    clear before. Also, the grep process returns an exit code of 1 if it
    didn't find a match, causing the job to cancel. The list of tests is
    space separated and should not be quoted but on the other hand, we
    do have to handle a literal *.
    Look for the right test and handle the grep exit code, and disable
    globs for the subshell for preserving a literal *.

## How to use

Pick to all channels

## Testing done

Local execution of the command pipe with cl.internet as argument and without, and checking that it has a 0 exit code.