### PR TITLE
build_library/set_release: add CPE_NAME - v2.3

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -57,6 +57,7 @@ ANSI_COLOR="38;5;75"
 HOME_URL="https://flatcar-linux.org/"
 BUG_REPORT_URL="https://issues.flatcar-linux.org"
 FLATCAR_BOARD="$FLAGS_board"
+CPE_NAME="cpe:2.3:o:${OS_ID}-linux:${OS_ID}_linux:${FLATCAR_VERSION}:*:*:*:*:*:*:*"
 EOF
 sudo ln -sf "../usr/lib/os-release" "${ROOT_FS_DIR}/etc/os-release"
 sudo ln -sf "../../lib/os-release" "${ROOT_FS_DIR}/usr/share/flatcar/os-release"


### PR DESCRIPTION
Flatcar is in the NIST CPE dictionary. Let's programmatically build the
`CPE_NAME` in the build process in order to be scanned.

`CPE_NAME` is part of `/etc/os-release` with the following manual entry:

```
CPE_NAME=
  A CPE name for the operating system, in URI binding syntax, following the Common Platform Enumeration Specification[2] as proposed by the NIST.
  This field is optional. Example: "CPE_NAME="cpe:/o:fedoraproject:fedora:17""
...
[^2]: Common Platform Enumeration Specification
           http://scap.nist.gov/specifications/cpe/
```

Which indicates that the current version of CPE is 2.3.

Closes: https://github.com/flatcar-linux/Flatcar/issues/536

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4230/cldsv/

Output example with the image provided by this CI :arrow_up: :
``` 
[bound] core@localhost ~ $ cat /etc/os-release
NAME="Flatcar Container Linux by Kinvolk"
ID=flatcar
ID_LIKE=coreos
VERSION=2021.11.23+dev-flatcar-master-4230
VERSION_ID=2021.11.23
BUILD_ID=dev-flatcar-master-4230
PRETTY_NAME="Flatcar Container Linux by Kinvolk 2021.11.23+dev-flatcar-master-4230 (Oklo)"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar-linux.org/"
BUG_REPORT_URL="https://issues.flatcar-linux.org"
FLATCAR_BOARD="amd64-usr"
CPE_NAME="cpe:2.3:o:flatcar-linux:flatcar_linux:2021.11.23+dev-flatcar-master-4230:*:*:*:*:*:*:*"
``` 