### PR TITLE
jenkins: make release.sh publish arm64 for Beta

### DIFF
--- a/changelog/bugfixes/2021-12-09-jenkins-arm64-beta.md
+++ b/changelog/bugfixes/2021-12-09-jenkins-arm64-beta.md
@@ -1,0 +1,1 @@
+- jenkins: make release.sh publish arm64 AMIs for beta [PR#188](https://github.com/flatcar-linux/scripts/pull/188)

--- a/jenkins/release.sh
+++ b/jenkins/release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 case "${CHANNEL}" in
-    stable|beta)
+    stable)
         boards=( amd64-usr )
         ;;
     *)


### PR DESCRIPTION
Now that arm64 images are available for Beta channel, we need to also add arm64 to Beta boards.

See also https://github.com/flatcar-linux/Flatcar/issues/570 .

After merging the PR, we should actually run again `os/release` of Jenkins.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
