### PR TITLE
jenkins: make release.sh publish arm64 for Stable

### DIFF
--- a/changelog/bugfixes/2021-12-10-jenkins-arm64-stable.md
+++ b/changelog/bugfixes/2021-12-10-jenkins-arm64-stable.md
@@ -1,0 +1,1 @@
+- jenkins: make release.sh publish arm64 AMIs for stable [PR#189](https://github.com/flatcar-linux/scripts/pull/189)

--- a/jenkins/release.sh
+++ b/jenkins/release.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 case "${CHANNEL}" in
-    stable)
-        boards=( amd64-usr )
-        ;;
     *)
       	boards=( amd64-usr arm64-usr )
         ;;


### PR DESCRIPTION
From flatcar-3033 on, arm64 images are available for Stable channel, we need to also add arm64 to Stable boards.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
