### PR TITLE
*: Replace kinvolk github org with flatcar-linux

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -151,7 +151,7 @@ stage_repo() {
         info "Using git ref '$gitref' for ebuild repo '$repo' ('$gitname') in stage 1."
         mkdir "$dest/$repo"
         (   cd "$dest/$repo" \
-            && git clone "https://github.com/kinvolk/$gitname.git" . \
+            && git clone "https://github.com/flatcar-linux/$gitname.git" . \
             && git fetch --all \
             && git checkout "$gitref" )
     fi

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -310,7 +310,7 @@ get_metadata() {
     if [ "${key}" = "SRC_URI" ]; then
         local package_name="$(echo "${pkg%%:*}" | cut -d / -f 2)"
         local ebuild_path="${prefix}/var/db/pkg/${pkg%%:*}/${package_name}.ebuild"
-        # SRC_URI is empty for the special github.com/kinvolk projects
+        # SRC_URI is empty for the special github.com/flatcar-linux projects
         if [ -z "${val}" ]; then
             # The grep invocation gives errors when the ebuild file is not present.
             # This can happen if a "scripts" branch does not match the "coreos-overlay" branch
@@ -318,7 +318,7 @@ get_metadata() {
             val="$(grep "CROS_WORKON_PROJECT=" "${ebuild_path}" | cut -d '"' -f 2)"
             if [ -n "${val}" ]; then
                 val="https://github.com/${val}"
-                # All github.com/kinvolk projects specify their commit
+                # All github.com/flatcar-linux projects specify their commit
                 local commit=""
                 commit="$(grep "CROS_WORKON_COMMIT=" "${ebuild_path}" | cut -d '"' -f 2)"
                 if [ -n "${commit}" ]; then
@@ -358,7 +358,7 @@ get_metadata() {
 #       "licenses": ["GPL-2", "LGPL-2.1", "MIT", "public-domain"],
 #       "description": "System and service manager for Linux",
 #       "homepage": "https://www.freedesktop.org/wiki/Software/systemd",
-#       "source": "https://github.com/kinvolk/systemd ",
+#       "source": "https://github.com/flatcar-linux/systemd ",
 #       "files": "somefile 63a5736879fa647ac5a8d5317e7cb8b0\nsome -> link\n"
 #     }
 #   ]
@@ -454,9 +454,9 @@ You can read it with "less licenses.json.bz2" or convert it to a text format wit
 bzcat licenses.json.bz2 | jq -r '.[] | "\(.project):\nDescription: \(.description)\nLicenses: \(.licenses)\nHomepage: \(.homepage)\nSource code: \(.source)\nFiles:\n\(.files)\n"'
 The license texts are available under /usr/share/licenses/common/ and can be read with "less NAME.gz".
 Build system files and patches used to build these projects are located at:
-https://github.com/kinvolk/coreos-overlay/
-https://github.com/kinvolk/portage-stable/
-https://github.com/kinvolk/flatcar-scripts/
+https://github.com/flatcar-linux/coreos-overlay/
+https://github.com/flatcar-linux/portage-stable/
+https://github.com/flatcar-linux/scripts/
 Information on how to build Flatcar Container Linux can be found under:
 https://docs.flatcar-linux.org/os/sdk-modifying-flatcar/
 EOF

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -50,12 +50,12 @@ disabled = true
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git
-sync-uri = https://github.com/kinvolk/coreos-overlay.git
+sync-uri = https://github.com/flatcar-linux/coreos-overlay.git
 
 [portage-stable]
 location = /var/lib/portage/portage-stable
 sync-type = git
-sync-uri = https://github.com/kinvolk/portage-stable.git
+sync-uri = https://github.com/flatcar-linux/portage-stable.git
 EOF
 
     # Now set the correct profile

--- a/changelog/bugfixes/2021-12-22-fix-dev-container.md
+++ b/changelog/bugfixes/2021-12-22-fix-dev-container.md
@@ -1,0 +1,1 @@
+- dev container: Fix github URL for coreos-overlay and portage-stable to use repos from flatcar-linux org directly instead of relying on redirects from the kinvolk org. This fixes checkouts with emerge-gitclone inside dev-container. [PR#194](https://github.com/flatcar-linux/scripts/pull/194)


### PR DESCRIPTION
Stop relying on github redirects, they are a mixed blessing and using
them broke emerge-gitclone inside dev-container in silent way. The
script could not find a desired revision of portage-stable or
coreos-overlay, because it tried to pull from kinvolk instead of
flatcar-linux github org. The redirects seem to hinder fetching a
specific commit, so the script pulled something else (HEAD or main?).

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

CI: http://localhost:9091/job/os/job/manifest/4445/cldsv/

Fixes https://github.com/flatcar-linux/Flatcar/issues/577