### PR TITLE
run_sdk_container: use exact match for existing containers

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -77,7 +77,7 @@ if [ -z "$name" ] ; then
     name="flatcar-sdk-${arch}-${docker_sdk_vernum}_os-${docker_os_vernum}"
 fi
 
-stat="$(docker ps --all --no-trunc --filter name="$name" --format '{{.Status}}'\
+stat="$(docker ps --all --no-trunc --filter name="^/$name\$" --format '{{.Status}}'\
         | cut -f1 -d' ')"
 
 # pass SDK related environment variables and gcloud auth


### PR DESCRIPTION
`run_sdk_container` uses the sourcetree version to decide whether to re-use existing containers or create new ones. However, containers were not matched by exact name - instead, plain `--filter name="..."` was used, leading to prefix matching. This change updates `name="..."` to use regular expressions for exact matching.

This change should be cherry-picked into the release branches flatcar-3033, flatcar-3066, and into the upcoming Alpha release branch.