### PR TITLE
build_packages: fix default torcx output root

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -36,7 +36,7 @@ DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update toolchain automatically."
 DEFINE_boolean skip_chroot_upgrade "${FLAGS_FALSE}" \
   "Don't run the chroot upgrade automatically; use with care."
-DEFINE_string torcx_output_root "${DEFAULT_BUILD_ROOT}" \
+DEFINE_string torcx_output_root "${DEFAULT_BUILD_ROOT}/torcx" \
   "Directory in which to place torcx stores and manifests (named by board/version)"
 DEFINE_boolean skip_torcx_store "${FLAGS_FALSE}" \
   "Don't build a new torcx store from the updated sysroot."


### PR DESCRIPTION
In 9fba5789f95bf79a393c5e35cb2346d3900e29ba we introduced  `--torcx_output_root` as an optional command line parameter and had it default to `${DEFAULT_BUILD_ROOT}`, inadvertently  diverging from the previous default, which was `${DEFAULT_BUILD_ROOT}/torcx`.

This change sets the correct default root `${DEFAULT_BUILD_ROOT}/torcx` to bring `build_packages` back into alignment with `build_image` (as well as the lower level `build_torcx_store`).

This change should be cherry-picked into the release branches flatcar-3033, flatcar-3066, and into the upcoming Alpha release branch.