### PR TITLE
ci-automation: allow to optionally push and sign the commit

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -61,7 +61,16 @@ function update_and_push_version() {
 
     git commit --allow-empty -m "New version: ${version}"
 
-    git tag -f "${version}"
+    local -a TAG_ARGS
+    if [ "${SIGN-0}" = 1 ]; then
+      TAG_ARGS=("-s" "-m" "${version}")
+    fi
+
+    git tag -f "${TAG_ARGS[@]}" "${version}"
+
+    if [ "${PUSH-0}" = 1 ]; then
+      git push
+    fi
 
     if git push origin "${version}" ; then
         return


### PR DESCRIPTION
For test builds the commit that updates the submodules can be free-
standing but for releases we need to push it to the branch and also
sign the tag.
Add optional arguments that are used by the tag-release script in
flatcar-build-scripts.


## How to use

Port to all active branches (except flatcar-lts-2605)

## Testing done

None