### PR TITLE
sdk_lib/sdk_entry.sh: use a login shell to source /etc/profile

### DIFF
--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -22,7 +22,7 @@ chown -R sdk:sdk /home/sdk
 #    our quotes for su -c "<cmd>" already.
 if [ $# -gt 0 ] ; then
     cmd="/home/sdk/.cmd"
-    echo -n "exec bash -i -c '" >"$cmd"
+    echo -n "exec bash -l -i -c '" >"$cmd"
     for arg in "$@"; do
         echo -n "\"$arg\" " >>"$cmd"
     done
@@ -33,5 +33,5 @@ if [ $# -gt 0 ] ; then
     rm -f "$cmd"
     exit $rc
 else
-    exec sudo su sdk
+    exec sudo su -l sdk
 fi


### PR DESCRIPTION
    For execution of the compiled binaries in /build/arm64-usr we rely on
    qemu-user binfmt emulation and have to tell it where the root is with
    QEMU_LD_PREFIX because build systems don't chroot into /build/arm64-usr
    themselves (which also works just by chance on amd64 because we have
    similar glibc versions and so on). The env var setup was done in
    /etc/profile.d/qemu-aarch64.sh but is now not read anymore since the
    container runs the shell not as login shell.
    
    Add the login options to the bash and su calls when starting the
    container.

## How to use

Check that `env` really prints out `QEMU_LD_PREFIX=/build/arm64-usr/`

Backport to all active branches

## Testing done

Manual edit of the file
