### PR TITLE
sdk_entry.sh: ensure currect binpkg host

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -119,7 +119,7 @@ fi
 
 if [ "$stat" != "Up" ] ; then
     yell "Starting stopped container '$name'"
-    trap "docker stop $name" EXIT
+    trap "docker stop -t 0 $name" EXIT
     docker start "$name"
 
 fi


### PR DESCRIPTION
This change ensures the binpkg host is updated if the board (OS) version differs from the SDK version.
This is to ensure /build/[arch] uses the correct binary package cache.

The change aims to address an [issue](https://github.com/flatcar-linux/flatcar-docs/pull/195#discussion_r778978471) uncovered by @pothos while reviewing documentation changes.

Also, a minor one-line change in `run_sdk_container` reduces the shutdown time of the SDK container, fixing a 10s lag when exiting the SDK.