### PR TITLE
sdk_lib/sdk_entry: handle permission error for target version file

### DIFF
--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -29,7 +29,7 @@ chown -R sdk:sdk /home/sdk
             echo "Updating board support in '/build/${target}' to use package cache for version '${FLATCAR_VERSION_ID}'"
             echo "---"
             sudo su sdk -l -c "/home/sdk/trunk/src/scripts/setup_board --board='$target' --regen_configs_only"
-            echo "TARGET_FLATCAR_VERSION_ID='${FLATCAR_VERSION_ID}'" > "/build/$target/etc/target-version.txt"
+            echo "TARGET_FLATCAR_VERSION_ID='${FLATCAR_VERSION_ID}'" | sudo tee "/build/$target/etc/target-version.txt" >/dev/null
         done
     fi
 )


### PR DESCRIPTION
The creation of the target version file failed:
/home/sdk/sdk_entry.sh: line 32: /build/amd64-usr/etc/target-version.txt: Permission denied

Use root permissions to create the file.

## How to use

Port to 3033 and 3066 branches

## Testing done

None
