### PR TITLE
Dockerfile.sdk-import: run update_chroot before setup_board

### DIFF
--- a/sdk_lib/Dockerfile.sdk-import
+++ b/sdk_lib/Dockerfile.sdk-import
@@ -6,6 +6,10 @@ RUN touch /etc/debian_chroot
 RUN chmod 644 /etc/passwd
 RUN chmod 644 /etc/group
 
+# User "root" is not in /etc/passwd / group in the SDK tarball
+RUN echo 'root:x:0:0:root:/root:/bin/bash' >>/etc/passwd
+RUN echo 'root:x:0:' >>/etc/group
+
 RUN if ! grep -q portage /etc/group ; then \
         echo "portage::250:portage" >>/etc/group; \
     fi
@@ -43,11 +47,12 @@ RUN echo 'export PATH="$PATH:/usr/local/bin:/usr/local/sbin"' >> /home/sdk/.bash
 RUN echo "if [ -f /mnt/host/source/.env ]; then source /mnt/host/source/.env; fi" >> /home/sdk/.bashrc
 RUN echo "if [ -f /mnt/host/source/.sdkenv ]; then source /mnt/host/source/.sdkenv; fi" >> /home/sdk/.bashrc
 
-COPY --chown=sdk:sdk sdk_lib/sdk_entry.sh /home/sdk
-RUN chmod 755 /home/sdk/sdk_entry.sh
-
 # This should be a NOP; if you see packages being rebuilt
 #  it's likely that submodules and SDK tarball are out of sync
-RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
+USER root:root
+RUN su sdk -l -c "FEATURES='-ipc-sandbox -network-sandbox -pid-sandbox' /home/sdk/trunk/src/scripts/update_chroot --toolchain_boards='amd64-usr arm64-usr'"
+
+COPY --chown=sdk:sdk sdk_lib/sdk_entry.sh /home/sdk
+RUN chmod 755 /home/sdk/sdk_entry.sh
 
 ENTRYPOINT /home/sdk/sdk_entry.sh


### PR DESCRIPTION
In PR https://github.com/flatcar-linux/scripts/pull/201 we added a call to setup_board to the SDK entry point `sdk_entry.sh`. Since we make use of `sdk_entry.sh` during the SDK container build, this inadvertently led to setup_board being called before update_chroot ran.

This fix does not call sdk_entry.sh for update_chroot, preventing the issue.

The fix should be cherry-picked to flatcar-3033 and flatcar-3066, too.