### PR TITLE
fix sdk_entry.sh setup_board fallout

### DIFF
--- a/sdk_lib/Dockerfile.sdk-import
+++ b/sdk_lib/Dockerfile.sdk-import
@@ -6,6 +6,10 @@ RUN touch /etc/debian_chroot
 RUN chmod 644 /etc/passwd
 RUN chmod 644 /etc/group
 
+# User "root" is not in /etc/passwd / group in the SDK tarball
+RUN echo 'root:x:0:0:root:/root:/bin/bash' >>/etc/passwd
+RUN echo 'root:x:0:' >>/etc/group
+
 RUN if ! grep -q portage /etc/group ; then \
         echo "portage::250:portage" >>/etc/group; \
     fi
@@ -46,6 +50,7 @@ RUN echo "if [ -f /mnt/host/source/.sdkenv ]; then source /mnt/host/source/.sdke
 COPY --chown=sdk:sdk sdk_lib/sdk_entry.sh /home/sdk
 RUN chmod 755 /home/sdk/sdk_entry.sh
 
+USER root:root
 # This should be a NOP; if you see packages being rebuilt
 #  it's likely that submodules and SDK tarball are out of sync
 RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"

--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -18,6 +18,9 @@ chown -R sdk:sdk /home/sdk
 
     if [ "${FLATCAR_VERSION_ID}" != "${DISTRIB_RELEASE}" ] ; then
         for target in amd64-usr arm64-usr; do
+            if [ ! -d "/build/$target" ] ; then
+                continue
+            fi
             if [ -f "/build/$target/etc/target-version.txt" ] ; then
                 source "/build/$target/etc/target-version.txt"
                 if [ "${TARGET_FLATCAR_VERSION_ID}" = "${FLATCAR_VERSION_ID}" ] ; then


### PR DESCRIPTION
In PR #201 we added a call to setup_board to the SDK entry point sdk_entry.sh. Since we make use of sdk_entry.sh during the SDK container build, this inadvertently led to setup_board being called before update_chroot ran.

This fix adds a check to sdk_entry.sh and only calls setup_board when `/build/...` exists. Additionally, it updates `sdk_lib/Dockerfile.sdk-import` to switch to the root user by default since `sdk_entry.sh` expects to be run as root.

Supersedes https://github.com/flatcar-linux/scripts/pull/204.

The fix should be cherry-picked to flatcar-3033 and flatcar-3066, too.