### PR TITLE
build_sdk_container_image: force removal of running container

### DIFF
--- a/build_sdk_container_image
+++ b/build_sdk_container_image
@@ -178,7 +178,7 @@ else
         rm "${tarball_copied}"
     fi
 
-    $docker container rm "${toolchains_container}"
+    $docker container rm -f "${toolchains_container}"
 
     docker_interface="docker0"
     if "${is_podman}"; then


### PR DESCRIPTION
At least with Podman it's not possible to call "container rm" on a
running container without the force flag.
Add the force flag which is also used elsewhere already.

## How to use

port to flatcar-3033 and 66

## Testing done

Manual removal worked with the flag
