### PR TITLE
ci-automation/garbage_collect: fix binpkg url

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -89,7 +89,7 @@ function garbage_collect() {
         else
             echo "## ${version} is an OS image version. ##"
             rmpat="${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-packages-*"
-            rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/binpkgs/boards/*/${os_docker_vernum}/*"
+            rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/binpkgs/boards/*/${os_vernum}/"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-images-*"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/images/*/${os_vernum}/"
         fi


### PR DESCRIPTION
`garbage_collect.sh` [was using 'docker_vernum'](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/garbage_collect.sh#L92) where it should have been using 'vernum' (as [`push_pkgs.sh`](https://github.com/flatcar-linux/scripts/blob/main/ci-automation/push_pkgs.sh#L64) does).

Also, make sure release directories are removed, not just packages.

This fix should be cherry-picked to 3066 and 3033.
