### PR TITLE
set_lsb_release: only set update-engine GROUP in /usr, not /etc

### DIFF
--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -73,7 +73,3 @@ sudo_clobber "${ROOT_FS_DIR}/usr/share/flatcar/update.conf" <<EOF
 SERVER=https://public.update.flatcar-linux.net/v1/update/
 GROUP=$FLAGS_group
 EOF
-
-sudo_clobber "${ROOT_FS_DIR}/etc/flatcar/update.conf" <<EOF
-GROUP=$FLAGS_group
-EOF

--- a/changelog/changes/2022-01-11-etc-flatcar-update-conf.md
+++ b/changelog/changes/2022-01-11-etc-flatcar-update-conf.md
@@ -1,0 +1,1 @@
+- Removed the pre-shipped `/etc/flatcar/update.conf` file, leaving it totally to the user to define the contents as it was unnecessarily overwriting the `/use/share/flatcar/update.conf` ([PR#212](https://github.com/flatcar-linux/scripts/pull/212))


### PR DESCRIPTION
The default image group is already encoded in
/usr/share/flatcar/update.conf but it was written to
/etc/flatcar/update.conf as well. This can cause problems when the user
switches channels by forcing an update to a specific release from the
different channel (e.g., through the flatcar-update tool) as it leaves
the file under /etc/flatcar/update.conf out of sync with the new
channel version in /usr/share/flatcar/update.conf.

Since we don't really need to write a specific channel to /etc on new
images as we can rely on the value from /usr, we now leave any possible
overwriting of the value in /etc entirely to the user.


## How to use


## Testing done

Scheduled test build and checked that the resulting image has the file missing as expected

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
