### PR TITLE
settings / ci-automation: remove "binpkg" prefix

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -89,7 +89,7 @@ function garbage_collect() {
         else
             echo "## ${version} is an OS image version. ##"
             rmpat="${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-packages-*"
-            rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/binpkgs/boards/*/${os_vernum}/"
+            rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/boards/*/${os_vernum}/"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-images-*"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/images/*/${os_vernum}/"
         fi

--- a/ci-automation/push_pkgs.sh
+++ b/ci-automation/push_pkgs.sh
@@ -27,7 +27,7 @@
 #
 # OUTPUT:
 #
-#   1. Binary packages published to buildcache at "binpkgs/boards/[ARCH]-usr/[VERSION]/pkgs".
+#   1. Binary packages published to buildcache at "boards/[ARCH]-usr/[VERSION]/pkgs".
 #   2. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 
@@ -41,7 +41,7 @@ function image_build__copy_to_bincache() {
     source ci-automation/ci_automation_common.sh
 
     cd /build/$arch-usr/var/lib/portage/pkgs/
-    copy_to_buildcache "binpkgs/boards/$arch-usr/$version/pkgs" *
+    copy_to_buildcache "boards/$arch-usr/$version/pkgs" *
 }
 # --
 

--- a/settings.env
+++ b/settings.env
@@ -5,4 +5,4 @@ SETTING_BINPKG_SERVER_PROD="https://mirror.release.flatcar-linux.net"
 
 # development servers / bin caches.
 SETTING_BINPKG_SERVER_DEV="https://bucket.release.flatcar-linux.net/flatcar-jenkins"
-SETTING_BINPKG_SERVER_DEV_CONTAINERISED="https://bincache.flatcar-linux.net/binpkgs"
+SETTING_BINPKG_SERVER_DEV_CONTAINERISED="https://bincache.flatcar-linux.net"


### PR DESCRIPTION
The original intention of the "binpkg" prefix in the CI binary package cache URL was to separate packages from other build artifacts like containers, images, and SDK tarballs. Motivation was to separate developer content (binary packages) from CI automation artifacts (everything else); since binary packages are not used by the CI.

This broke assumptions in scripts which use the binary host URL for other things than packages - e.g. SDK tarballs or images. These scripts would get a bincache URL with "binpkg/" prepended, while CI automation would *not* use that prefix.

This change removes the use of "binpkg/" altogether since it would not work as intended without more significant changes to build scripts.

This PR should be cherry-picked to all active release branches (likely flatcar-3033, flatcar-3066, and flatcar-3115).