### PR TITLE
build_library/check_root: ignore dangling '*egg-info' symlink

### DIFF
--- a/build_library/check_root
+++ b/build_library/check_root
@@ -127,7 +127,8 @@ IGNORE_SYMLINK = (
     b"/etc/lsb-release",  # set later in the build process
     b"/usr/share/coreos", # set later in the build process
     b"/etc/coreos",       # set later in the build process
-    b"/usr/src/linux-*/tools/testing/selftests/powerpc/copyloops/memcpy_mcsafe_64.S" # broken symlink in Kernel source tree
+    b"/usr/src/linux-*/tools/testing/selftests/powerpc/copyloops/memcpy_mcsafe_64.S", # broken symlink in Kernel source tree
+    b"/usr/lib*/python3*/site-packages/*egg-info", # broken symlink from dev-python/certifi that is not filtered by INSTALL_MASK
 )
 
 


### PR DESCRIPTION
# ignore one more dangling symlink when building for GCE

Ignore the broken '/usr/lib64/python3.9/site-packages/certifi-3021.3.16-py3.9.egg-info' symlink when building for GCE.
 
## How to use

```
./build_image --board=amd64-usr
./image_to_vm.sh --format gce --board=amd64-usr
```

## Testing done

```
./build_image --board=amd64-usr
./image_to_vm.sh --format gce --board=amd64-usr
```

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) - not user facing
