### PR TITLE
list torcx components in package list

### DIFF
--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -30,6 +30,7 @@ function torcx_manifest::add_pkg() {
   pkg_hash="${1}"; shift
   cas_digest="${1}"; shift
   source_package="${1}"; shift
+  meta_package="${1}"; shift
   update_default="${1}"; shift
 
   local manifest=$(cat "${path}")
@@ -39,6 +40,7 @@ function torcx_manifest::add_pkg() {
   "hash": "${pkg_hash}",
   "casDigest": "${cas_digest}",
   "sourcePackage": "${source_package}",
+  "metaPackage": "${meta_package}",
   "locations": []
 }
 EOF

--- a/build_library/torcx_manifest.sh
+++ b/build_library/torcx_manifest.sh
@@ -133,5 +133,18 @@ function torcx_manifest::default_version() {
 # sources_on_disk returns the list of source packages of all torcx images installed on disk
 function torcx_manifest::sources_on_disk() {
   local file="${1}"
-  jq -r ".value.packages[].versions[] | select(.locations[].path).sourcePackage" < "${file}"
+  local torcx_pkg=""
+  jq -r ".value.packages[].versions[] | select(.locations[].path).metaPackage" < "${file}" |
+  while read torcx_pkg; do
+    torcx_dependencies "${torcx_pkg}" | tr ' ' '\n'
+  done
 }
+
+# Print the first level of runtime dependencies for a torcx meta-package.
+function torcx_dependencies() (
+  pkg=${1:?}
+  ebuild=$(equery-${BOARD} w "${pkg}")
+  function inherit() { : ; }
+  . "${ebuild}"
+  echo ${RDEPEND}
+)

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -69,8 +69,9 @@ function torcx_dependencies() (
 
 # Build and install a package configured as part of a torcx image.
 function torcx_build() (
-        pkg=${2:?}
         tmproot=${1:?}
+        shift
+        pkgs=( "${@}" )
 
         export LDFLAGS=-Wl,-rpath,/ORIGIN/../lib
         export PKGDIR="${tmproot}/var/lib/portage/pkgs"
@@ -81,16 +82,18 @@ function torcx_build() (
 
         # Build binary packages using dev files in the board root.
         emerge-${BOARD} \
+            --jobs="${NUM_JOBS}" \
             --buildpkg \
             --buildpkgonly \
             --nodeps \
             --oneshot \
             --quiet \
             --root-deps=rdeps \
-            "${pkg}"
+            "${pkgs[@]}"
 
         # Install the binary packages in the temporary torcx image root.
         emerge-${BOARD} \
+            --jobs="${NUM_JOBS}" \
             --nodeps \
             --oneshot \
             --quiet \
@@ -98,7 +101,7 @@ function torcx_build() (
             --root-deps=rdeps \
             --sysroot="${tmproot}" \
             --usepkgonly \
-            "${pkg}"
+            "${pkgs[@]}"
 )
 
 # Create a torcx image from the given meta-package.
@@ -134,10 +137,7 @@ function torcx_package() {
         sudo ln -fns bin "${tmproot}/sbin"
 
         # Install the meta-package and its direct dependencies.
-        for deppkg in "=${pkg}" $(torcx_dependencies "${pkg}")
-        do
-                torcx_build "${tmproot}" "${deppkg}"
-        done
+        torcx_build "${tmproot}" "=${pkg}" $(torcx_dependencies "${pkg}")
 
         # by convention, the first dependency in a torcx package is the primary
         # source package

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -58,15 +58,6 @@ check_gsutil_opts
 
 TORCX_CAS_ROOT="${FLAGS_output_root}/pkgs/${BOARD}"
 
-# Print the first level of runtime dependencies for a torcx meta-package.
-function torcx_dependencies() (
-        pkg=${1:?}
-        ebuild=$(equery-${BOARD} w "${pkg}")
-        function inherit() { : ; }
-        . "${ebuild}"
-        echo ${RDEPEND}
-)
-
 # Build and install a package configured as part of a torcx image.
 function torcx_build() (
         tmproot=${1:?}

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -230,6 +230,7 @@ function torcx_package() {
             "sha512-${sha512sum}" \
             "${digest}" \
             "${source_pkg}" \
+            "${pkg}" \
             "${update_default}" \
             "${pkg_locations[@]}"
         )


### PR DESCRIPTION
# list torcx components in package list

Packages installed inside a torcx package where missing from the final image package list file that we provide along with the image. Add torcx components to the image package list.

## How to use

`./build_packages && ./build_image` and then inspect `flatcar_production_image_packages.txt`.

## Testing done

Checked that `app-emulation/containerd` shows up in `flatcar_production_image_packages.txt`.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
