### PR TITLE
build_library: vm_image_util: create fixed-size VHDs for Azure

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -283,12 +283,12 @@ IMG_exoscale_DISK_FORMAT=qcow2
 IMG_exoscale_OEM_PACKAGE=oem-exoscale
 
 ## azure
-IMG_azure_DISK_FORMAT=vhd
+IMG_azure_DISK_FORMAT=vhd_fixed
 IMG_azure_DISK_LAYOUT=azure
 IMG_azure_OEM_PACKAGE=oem-azure
 
 ## azure pro
-IMG_azure_pro_DISK_FORMAT=vhd
+IMG_azure_pro_DISK_FORMAT=vhd_fixed
 IMG_azure_pro_DISK_LAYOUT=azure
 IMG_azure_pro_OEM_PACKAGE=oem-azure-pro
 
@@ -429,6 +429,7 @@ _disk_ext() {
         vmdk_scsi) echo vmdk;;
         vmdk_stream) echo vmdk;;
         hdd) echo hdd;;
+        vhd*) echo vhd;;
         *) echo "${disk_format}";;
     esac
 }
@@ -576,6 +577,11 @@ _write_qcow2_disk() {
 
 _write_vhd_disk() {
     qemu-img convert -f raw "$1" -O vpc -o force_size "$2"
+    assert_image_size "$2" vpc
+}
+
+_write_vhd_fixed_disk() {
+    qemu-img convert -f raw "$1" -O vpc -o subformat=fixed,force_size "$2"
     assert_image_size "$2" vpc
 }
 

--- a/changelog/changes/2022-02-01-azure-fixed-vhd.md
+++ b/changelog/changes/2022-02-01-azure-fixed-vhd.md
@@ -1,0 +1,1 @@
+- Azure VHD disks are now created using subformat=fixed, which makes them suitable for immediate upload to Azure using any tool.


### PR DESCRIPTION
# build_library: vm_image_util: create fixed-size VHDs for Azure

Azure requires disks to be fixed-size VHD files when uploading to blob storage
in order to create image/gallery objects from them. This is documented here[1].
To prevent mistakes from happening create disks in that format directly so that
any azure compatible tool can upload them, though azcopy is recommend because
it handles their sparseness best.

This has not been an issue for us so far because kola uses code from an older
utility that transparently handled the dynamic-to-fixed-size conversion for VHD
files (azure-vhd-utils). But people working with these things for the first
time fall into this trap.

[1]: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic#resizing-vhds.


## How to use
```./image_to_vm.sh --format=azure```

## Testing done

```
$  ls -lah ../build/images/amd64-usr/latest/flatcar_production_azure_image.vhd 
-rw-r--r-- 1 azureuser azureuser 31G Feb  1 15:35 flatcar_production_azure_image.vhd
```

CI passed

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
