### PR TITLE
kola/em: increase timeout

### DIFF
--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -44,7 +44,7 @@ fi
 if [[ "${BOARD}" == "arm64-usr" ]]; then
   PACKET_REGION="da11"
   PARALLEL_TESTS="2"
-  timeout=10h
+  timeout=15h
 fi
 
 # Run the cl.internet test on multiple machine types only if it should run in general


### PR DESCRIPTION
number of test increased. While we don't have yet a way to reduce
testing time, let's increase the timeout.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>