### PR TITLE
jenkins: do not check out branches of coreos-overlay and portage-stable

### DIFF
--- a/jenkins/kola/dev-container.sh
+++ b/jenkins/kola/dev-container.sh
@@ -40,11 +40,6 @@ export PORTAGE_BINHOST="${PORTAGE_BINHOST}"
 export {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get --json-key=/opt/credentials.json --verify=true /opt/verify.asc \"\${URI}\" \"\${DISTDIR}/\${FILE}\""
 emerge-gitclone
 . /usr/share/coreos/release
-if [[ $FLATCAR_RELEASE_VERSION =~ master ]]
-then
-        git -C /var/lib/portage/portage-stable checkout master
-        git -C /var/lib/portage/coreos-overlay checkout master
-fi
 emerge -gv coreos-sources
 ln -fns /boot/config /usr/src/linux/.config
 exec make -C /usr/src/linux -j"$(nproc)" modules_prepare V=1


### PR DESCRIPTION
The default branch of both repos, coreos-overlay and portage-stable, should be `main`.
If we checkout `master` branch, which contains invalid source code that was deprecated many years ago, the build could sometimes fail, e.g. when trying to build perl 5.26.2 with gcc 10.

Simply delete the code checking out branches, as the part is already being handled in `emerge-gitclone`.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4782/cldsv

-  Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) - not needed as it is not an user-facing issue.
