### PR TITLE
build_library: update allow list for GLSA checks 2022-02-16

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-GLSA_WHITELIST=(
+GLSA_ALLOWLIST=(
 	201412-09 # incompatible CA certificate version numbers
 	201908-14 # backported both CVE fixes
 	201909-01 # Perl, SDK only
@@ -19,7 +19,7 @@ GLSA_WHITELIST=(
 )
 
 glsa_image() {
-  if glsa-check-$BOARD -t all | grep -Fvx "${GLSA_WHITELIST[@]/#/-e}"; then
+  if glsa-check-$BOARD -t all | grep -Fvx "${GLSA_ALLOWLIST[@]/#/-e}"; then
     echo "The above GLSAs apply to $ROOT"
     return 1
   fi
@@ -42,15 +42,15 @@ test_image_content() {
     #returncode=1
   fi
 
-  local blacklist_dirs=(
+  local denylist_dirs=(
     "$root/usr/share/locale"
   )
-  for dir in "${blacklist_dirs[@]}"; do
+  for dir in "${denylist_dirs[@]}"; do
     if [ -d "$dir" ]; then
-      warn "test_image_content: Blacklisted directory found: $dir"
+      warn "test_image_content: Denied directory found: $dir"
       # Only a warning for now, size isn't important enough to kill time
       # playing whack-a-mole on things like this this yet.
-      #error "test_image_content: Blacklisted directory found: $dir"
+      #error "test_image_content: Denied directory found: $dir"
       #returncode=1
     fi
   done

--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,18 +4,7 @@
 
 GLSA_ALLOWLIST=(
 	201412-09 # incompatible CA certificate version numbers
-	201908-14 # backported both CVE fixes
-	201909-01 # Perl, SDK only
-	202003-26 # SDK only
-	202005-09 # SDK only
-	202006-03 # perl, SDK only
-	202008-01 # python, SDK only
-	202101-18 # python, SDK only
-	202104-04 # python, SDK only
 	202105-22 # samba, not affected, samba has no ldap flag, no smbd.
-	202105-34 # bash, non-trivial
-	202107-31 # polkit, in-progress
-	202107-48 # systemd, backported fixes to v247.
 )
 
 glsa_image() {

--- a/common.sh
+++ b/common.sh
@@ -238,9 +238,9 @@ get_gclient_root() {
   fi
 }
 
-# Populate the ENVIRONMENT_WHITELIST array.
-load_environment_whitelist() {
-  ENVIRONMENT_WHITELIST=(
+# Populate the ENVIRONMENT_ALLOWLIST array.
+load_environment_allowlist() {
+  ENVIRONMENT_ALLOWLIST=(
     COREOS_OFFICIAL
     FLATCAR_BUILD_ID
     FORCE_STAGES
@@ -308,7 +308,7 @@ if [[ -f "${REPO_MANIFESTS_DIR}/version.txt" ]]; then
     FLATCAR_DEV_BUILDS FLATCAR_DEV_BUILDS_SDK
     # Don't promote FLATCAR_BUILD_ID into an environment variable when it
     # didn't start as one, since we don't want it leaking into the SDK
-    # chroot environment via ENVIRONMENT_WHITELIST.
+    # chroot environment via ENVIRONMENT_ALLOWLIST.
     declare +x FLATCAR_BUILD_ID
   fi
   : ${FLATCAR_BUILD_ID:=$(date +%Y-%m-%d-%H%M)}


### PR DESCRIPTION
Clean up following entries from the GLSA allow list.

* 201908-24: polkit 0.120-r2, so not affected
* 201909-01: perl 5.34.0, so not affected
* 202003-26: python 3.9.8, so not affected
* 202005-09: python 3.9.8, so not affected
* 202006-03: perl 5.34.0, so not affected
* 202008-01: python 3.9.8, so not affected
* 202101-18: python 3.9.8, so not affected
* 202104-04: python 3.9.8, so not affected
* 202105-34: bash 5.1_p8, so not affected
* 202107-31: polkit 0.120-r2, so not affected
* 202107-48: systemd 250.3, so not affected

Also replace `blacklist` with `denylist`, and `whitelist` with `allowlist`.

This PR should be merged together with https://github.com/flatcar-linux/portage-stable/pull/289.

## Testing done

CI passed: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4867/cldsv

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) - not needed
