### PR TITLE
build_library/build_image_util: disable ebuild-locks when merging bin…

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -155,6 +155,7 @@ emerge_to_image() {
   fi
 
   sudo -E ROOT="${root_fs_dir}" \
+      FEATURES="-ebuild-locks" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
       emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" -v "$@"
 


### PR DESCRIPTION
# build_library/build_image_util: disable ebuild-locks when merging binary packages

Set `FEATURES=-ebuild-locks` for the duration of the binary package merge to the image. This makes the operation much faster (20min -> 10min) and I haven't seen any issues with it so far.

## How to use

```
time ./build_image --board=amd64-usr
```

## Testing done

Have been using this for months, and CI running.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
