### PR TITLE
ci-automation: publish test results, add to GC

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -92,6 +92,7 @@ function garbage_collect() {
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/boards/*/${os_vernum}/"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-images-*"
             rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/images/*/${os_vernum}/"
+            rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/testing/${os_vernum}/"
         fi
 
         echo "## The following files will be removed ##"

--- a/ci-automation/packages.sh
+++ b/ci-automation/packages.sh
@@ -123,7 +123,7 @@ function packages_build() {
 
     # Publish torcx manifest and docker tarball to "images" cache so tests can pull it later.
     copy_to_buildcache "images/${arch}/${vernum}/torcx" \
-        "${torcx_tmp}/torcx/amd64-usr/latest/torcx_manifest.json"
+        "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json"
     copy_to_buildcache "images/${arch}/${vernum}/torcx" \
         "${torcx_tmp}/torcx/pkgs/${arch}-usr/docker/"*/*.torcx.tgz
 

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -179,7 +179,7 @@ function test_run() {
     # publish TAP files to build cache
     copy_to_buildcache "testing/${vernum}/${arch}/${image}" \
         "${tests_dir}/"*.tap
-    copy_to_buildcache "testing/${vernum}/${arch}/${image}/debug" \
-        "${tests_dir}/_kola_temp/"*
+    copy_to_buildcache "testing/${vernum}/${arch}/${image}" \
+        "${tests_dir}/_kola_temp"
 }
 # --

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -176,7 +176,7 @@ function test_run() {
         echo "########### All re-runs exhausted ($retries). Giving up. ###########"
     fi
 
-    # publish TAP files to buold cache
+    # publish TAP files to build cache
     copy_to_buildcache "testing/${vernum}/${arch}/${image}" \
         "${tests_dir}/"*.tap
     copy_to_buildcache "testing/${vernum}/${arch}/${image}/debug" \

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -176,9 +176,10 @@ function test_run() {
         echo "########### All re-runs exhausted ($retries). Giving up. ###########"
     fi
 
-    # TODO: publish to bincache?
-    # "${tests_dir}/"*.tap
-    # "${tests_dir}/_kola_temp.tar.xz"
-
+    # publish TAP files to buold cache
+    copy_to_buildcache "testing/${vernum}/${arch}/${image}" \
+        "${tests_dir}/"*.tap
+    copy_to_buildcache "testing/${vernum}/${arch}/${image}/debug" \
+        "${tests_dir}/_kola_temp/"*
 }
 # --


### PR DESCRIPTION
This change adds copying test results to the build cache server, and adds respective deletion to the garbage collector.
Also, the patch fixes an issue with torcx publishing (manifest publishing had arch hard-coded).