### PR TITLE
ci-automation: SDK build updates version.txt in main branch

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -48,6 +48,7 @@ function update_submodules() {
 
 function update_and_push_version() {
     local version="$1"
+    local push_to_branch="${2:-false}"
 
     # set up author and email so git does not complain when tagging
     if ! git config --get user.name >/dev/null 2>&1 ; then
@@ -71,8 +72,9 @@ function update_and_push_version() {
 
     git tag -f "${TAG_ARGS[@]}" "${version}"
 
-    if [ "${PUSH-0}" = 1 ]; then
-      git push
+    if [ "${push_to_branch}" = "true" ]; then
+      local branch="$(git rev-parse --abbrev-ref HEAD)"
+      git push origin "${branch}"
     fi
 
     if git push origin "${version}" ; then

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -86,10 +86,13 @@ function sdk_bootstrap() {
 
     # Create new tag in scripts repo w/ updated versionfile + submodules.
     # Also push the changes to the branch ONLY IF we're doing a nightly
-    #   build of the 'main' branch AND we're definitely ON the main branch.
+    #   build of the 'main' branch AND we're definitely ON the main branch
+    #   (`scripts` and submodules).
     local push_branch="false"
     if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+$ ]] \
-       && [ "$(git rev-parse --abbrev-ref HEAD)" = "main"  ] ; then
+       && [ "$(git rev-parse --abbrev-ref HEAD)" = "main"  ] \
+       && [ "$(git -C sdk_container/src/third_party/coreos-overlay/ rev-parse --abbrev-ref HEAD)" = "main"  ] \
+       && [ "$(git -C sdk_container/src/third_party/portage-stable/ rev-parse --abbrev-ref HEAD)" = "main"  ] ; then
         push_branch="true"
     fi
     update_and_push_version "sdk-${git_vernum}" "${push_branch}"

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -85,10 +85,11 @@ function sdk_bootstrap() {
     cd -
 
     # Create new tag in scripts repo w/ updated versionfile + submodules.
-    # When on the 'main' branch then also push to the branch so the versionfile
-    #  and git submodules stay up to date.
+    # Also push the changes to the branch ONLY IF we're doing a nightly
+    #   build of the 'main' branch AND we're definitely ON the main branch.
     local push_branch="false"
-    if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] ; then
+    if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+$ ]] \
+       && [ "$(git rev-parse --abbrev-ref HEAD)" = "main"  ] ; then
         push_branch="true"
     fi
     update_and_push_version "sdk-${git_vernum}" "${push_branch}"

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -84,7 +84,13 @@ function sdk_bootstrap() {
     copy_to_buildcache "sdk/${ARCH}/${vernum}" "${dest_tarball}"*
     cd -
 
-    # Create new tag in scripts repo w/ updated versionfile + submodules
-    update_and_push_version "sdk-${git_vernum}"
+    # Create new tag in scripts repo w/ updated versionfile + submodules.
+    # When on the 'main' branch then also push to the branch so the versionfile
+    #  and git submodules stay up to date.
+    local push_branch="false"
+    if [ "$(git rev-parse --abbrev-ref HEAD)" = "main" ] ; then
+        push_branch="true"
+    fi
+    update_and_push_version "sdk-${git_vernum}" "${push_branch}"
 }
 # --


### PR DESCRIPTION
This change has sdk_bootstrap push the branch to origin when run from the main branch, updating the SDK and OS version in 'main' for each SDK bootstrap build.

Release / maintenance branches have the SDK version set in the versionfile at release time. But main is never updated.

Updating the versionfile in main when a new SDK is built ensures that dev branches based on main will also use the correct SDK version (e.g.in subsequent CI builds). As an example, this PR makes changes like these: https://github.com/flatcar-linux/scripts/pull/235/files#diff-48b3a88e2d986f5123acefc4dd59b5e6ae86f45975cc28e105e3ed1b3815f420L4 unnecessary.

Note this change implies we'll have one automated commit each night in our main branch, from the nightly build.

As a (positive) side effect this will also update `main`s submodule pinnings to the `main` tips in coreos-overlay and portage-stable every night.