### PR TITLE
ci-automation: fix test_update_reruns typo

### DIFF
--- a/ci-automation/test_update_reruns.sh
+++ b/ci-automation/test_update_reruns.sh
@@ -22,5 +22,5 @@ merged_detailed="$8"
 source ci-automation/tapfile_helper_lib.sh
 tap_ingest_tapfile "${tapfile}" "${image}" "${retry}"
 tap_failed_tests_for_vendor "${image}" > "${failfile}"
-tap_generate_report "${arch}" "${version}"  > "${merged_summary}"
-tap_generate_report "${arch}" "${version}"  "true" > "${merged_detailed}"
+tap_generate_report "${arch}" "${vernum}"  > "${merged_summary}"
+tap_generate_report "${arch}" "${vernum}"  "true" > "${merged_detailed}"


### PR DESCRIPTION
Fixes `ci-automation/test_update_reruns.sh: line 25: version: unbound variable` observed in today's nightlies' containerised tests.

This PR should be cherry-picked to flatcar-3033, flatcar-3066, and flatcar-3139 after merge.