### PR TITLE
ci-automation: foundation for package + sdk update

### DIFF
--- a/ci-automation/sdk_container_update.sh
+++ b/ci-automation/sdk_container_update.sh
@@ -64,7 +64,7 @@ function sdk_container_update_generate_new_version() {
 
     local current_major_minor="$(echo "${current_vernum}" | sed 's/^\([0-9]\+\.[0-9]\+\).*/\1/')"
     local current_patchlevel="$(echo "${current_vernum}" | sed 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/')"
-    local current_suffix="$(echo "${current_vernum}" | sed 's/^\([0-9]\+\.[0-9]\+\.[0-9]\+\)//')"
+    local current_suffix="$(echo "${current_vernum}" | sed 's/^[0-9]\+\.[0-9]\+\.[0-9]\+//')"
 
     current_patchlevel="$((current_patchlevel + 1))"
     echo "${current_major_minor}.${current_patchlevel}${current_suffix}"

--- a/ci-automation/sdk_container_update.sh
+++ b/ci-automation/sdk_container_update.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# >>> This file is supposed to be SOURCED from the repository ROOT. <<<
+#
+# sdk_container_update() should be called w/ the positional INPUT parameters below.
+
+# SDK container update automation stub.
+#  This script will create a new SDK container image based on an existing container image.
+#  It is meant to be used for updating tools in the SDK that do not directly affect OS image
+#  generation - like e.g. the mantle suite tools (kola, ore, etc.).
+#
+# PREREQUISITES:
+#
+#   1. SDK version is recorded in sdk_container/.repo/manifests/version.txt and a matching source
+#       SDK container is available on build cache at "/containers/[VERSION]/flatcar-sdk-all-[VERSION].tar.gz"
+#         (nightly / dev builds)
+#      OR
+#       SDK image is available on ghcr.io/flatcar-linux/flatcar-sdk-all:[VERSION]
+#         (official SDK releases)
+#      Specifically, the "-all" version of the source SDK image is required.
+#
+# OPTIONAL INPUT
+#
+#   1. Target SDK version number (without alpha-/beta-/etc. prefix).
+#      If not provided it will be computed from the source SDK, and the patch level is bumped
+#      (e.g. 3139.0.0 => 3139.0.1).
+#
+#   2. coreos-overlay repository tag to use (commit-ish).
+#       Optional - use scripts repo sub-modules as-is if not set.
+#       This version will be checked out / pulled from remote in the coreos-overlay git submodule.
+#       The submodule config will be updated to point to this version before the TARGET SDK tag is created and pushed.
+#
+#   3. portage-stable repository tag to use (commit-ish).
+#       Optional - use scripts repo sub-modules as-is if not set.
+#       This version will be checked out / pulled from remote in the portage-stable git submodule.
+#       The submodule config will be updated to point to this version before the TARGET SDK tag is created and pushed.
+#
+# OUTPUT:
+#
+#   1. SDK container image of the new SDK, published to buildcache
+#       at "/containers/[NEW_VERSION]/flatcar-sdk-all-[NEW_VERSION].tar.gz"
+#
+#   2. New SDK version tagged in scripts and tag pushed to origin.
+#
+#   3. "./ci-cleanup.sh" with commands to clean up temporary build resources,
+#        to be run after this step finishes / when this step is aborted.
+
+set -euo pipefail
+
+# Helper function to generate a new version from the current SDK version
+#  in version.txt.
+# Can also be used by CI automation to generate "$1" for sdk_container_update
+#  coreos_git and portage_git are to be provided.
+#
+function sdk_container_update_generate_new_version() {
+    source ci-automation/ci_automation_common.sh
+    source sdk_container/.repo/manifests/version.txt
+
+    local current_vernum="${FLATCAR_SDK_VERSION}"
+
+    local current_major_minor="$(echo "${current_vernum}" | sed 's/^\([0-9]\+\.[0-9]\+\).*/\1/')"
+    local current_patchlevel="$(echo "${current_vernum}" | sed 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/')"
+    local current_suffix="$(echo "${current_vernum}" | sed 's/^\([0-9]\+\.[0-9]\+\.[0-9]\+\)//')"
+
+    current_patchlevel="$((current_patchlevel + 1))"
+    echo "${current_major_minor}.${current_patchlevel}${current_suffix}"
+}
+# --
+
+function sdk_container_update() {
+    local vernum="${1:-}"
+    local coreos_git="${2:-}"
+    local portage_git="${3:-}"
+
+    source ci-automation/ci_automation_common.sh
+    init_submodules
+
+    # Make sure source SDK is present for `update_sdk_container_image`
+    source sdk_container/.repo/manifests/version.txt
+    local source_docker_vernum="$(vernum_to_docker_image_version "${FLATCAR_SDK_VERSION}")"
+    docker_image_from_registry_or_buildcache "flatcar-sdk-all" "${source_docker_vernum}"
+    local source_sdk_image="$(docker_image_fullname "flatcar-sdk-all" "${source_docker_vernum}")"
+    echo "docker image rm -f '${source_sdk_image}'" >> ./ci-cleanup.sh
+
+    if [ -n "${coreos_git}" ] ; then
+        update_submodule "coreos-overlay" "${coreos_git}"
+    fi
+    if [ -n "${portage_git}" ] ; then
+        update_submodule "portage-stable" "${portage_git}"
+    fi
+
+    if [ -z "${vernum}" ] ; then
+        vernum="$(sdk_container_update_generate_new_version)"
+    fi
+
+    ./update_sdk_container_image -x ./ci-cleanup.sh "${vernum}"
+
+    local docker_vernum="$(vernum_to_docker_image_version "${vernum}")"
+    docker_image_to_buildcache "${CONTAINER_REGISTRY}/flatcar-sdk-all" "${docker_vernum}"
+    docker_image_to_buildcache "${CONTAINER_REGISTRY}/flatcar-sdk-amd64" "${docker_vernum}"
+    docker_image_to_buildcache "${CONTAINER_REGISTRY}/flatcar-sdk-arm64" "${docker_vernum}"
+
+    update_and_push_version "sdk-${vernum}"
+}
+# --

--- a/ci-automation/util/update_cros_workon.sh
+++ b/ci-automation/util/update_cros_workon.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Helper script to update an ebuild's CROS_WORKON_COMMIT to the tip of a branch
+#  (HEAD by default).
+#
+# PREREQUISITES:
+#
+#   1. The ebuild to be updated uses CROS_WORKON_COMMIT.
+#   2. the directory the ebuild is in follows the pattern of
+#      - exactly one "versioned" ebuild which is a soft-link to the actual ebuild
+#      - the actual ebuild conforms to <name>-9999.ebuild
+#
+# INPUT
+#
+#   1. Path to the ebuild directory.
+#
+# OPTIONAL INPUT
+#
+#   2. Branch to update the ebuild to. The latest commit of the branch will be used.
+#       Defaults to HEAD (i.e. the repo's default branch).
+#   3. "true" if a git commit (both in the submodule as well as in scripts) should be created.
+#       Defaults to "false".
+#
+
+function update_cros_workon() {
+    set -euo pipefail
+
+    local ebuild_dir="$1"
+    local branch="${2:-HEAD}"
+    local commit="${3:-false}"
+
+    # Use a subshell and operate directly in $ebuild_dir
+    (
+        cd "${ebuild_dir}"
+        softlink="$(basename $(find . -type l))"
+
+        name="$(echo "${softlink}" | sed 's/^\(.*\)-[0-9.]\+[-.]*.*\.ebuild/\1/')"
+        version="$(echo "${softlink}" | sed 's/^.*-\([0-9.]\+\)[-.]*.*\.ebuild/\1/')"
+        release="$(echo "${softlink}" | sed -n 's/.*-[0-9.]\+[-.]r\([0-9]\+\)\.ebuild/\1/p')"
+        new_release="$((release + 1))"
+
+        ebuild="${name}-9999.ebuild"
+        new_softlink="${name}-${version}-r${new_release}.ebuild"
+        ln -s "${ebuild}" "${new_softlink}"
+
+        local repo="$(eval "$(grep -E '(CROS_WORKON_REPO|CROS_WORKON_PROJECT)' "${ebuild}")"
+                      echo $CROS_WORKON_REPO/$CROS_WORKON_PROJECT)"
+        commit_id="$(git ls-remote "${repo}" "${branch}" | awk "/[[:space:]]${branch}/ {print \$1}")"
+
+        sed -i "s/CROS_WORKON_COMMIT.*/CROS_WORKON_COMMIT=\"${commit_id}\" # tip of branch ${branch} $(date)/" \
+                "${ebuild}"
+
+        rm "${softlink}"
+
+        echo "Updated '${ebuild}' to commit '${commit_id}'"
+        echo " ('${softlink}' ==> '${new_softlink}'"
+
+        if [ "${commit}" = "true" ] then
+            git add .
+            git commit -m "${new_softlink}: Update ${name} to latest ${branch}"
+        fi
+    )
+
+    if [ "${commit}" = "true" ] then
+        local submodule_path="$(echo "${ebuild_dir}" \
+                                | sed -n 's/\(coreos-overlay\|portage-stable\).*/\1/p')"
+        local submodule="$(basename "${submodule_path}")"
+        git commit -m "${submodule}: Update ${name} to latest ${branch}" "${submodule_path}"
+    fi
+}
+# --
+
+if [ "$(basename "${BASH_SOURCE[0]}")" = "update_cros_workon.sh" ] ; then
+    update_cros_workon $@
+fi

--- a/ci-automation/util/update_cros_workon.sh
+++ b/ci-automation/util/update_cros_workon.sh
@@ -22,8 +22,9 @@
 #
 #   2. Branch to update the ebuild to. The latest commit of the branch will be used.
 #       Defaults to HEAD (i.e. the repo's default branch).
-#   3. "true" if a git commit (both in the submodule as well as in scripts) should be created.
-#       Defaults to "false".
+#   3. "false" by default.
+#      "commit" - create a git commit both in the submodule as well as in scripts after updating.
+#      "push" - implies "commit". Create commits and push the submodule branch (but not "scripts").
 #
 
 function update_cros_workon() {
@@ -59,15 +60,19 @@ function update_cros_workon() {
         echo "Updated '${ebuild}' to commit '${commit_id}'"
         echo " ('${softlink}' ==> '${new_softlink}'"
 
-        if [ "${commit}" = "true" ] then
+        if [[ "${commit}" =~ (commit|push) ]] ; then
             git add .
             local category="$(dirname "${PWD}")"
             category="${category##*/}" # strip everything from the beginning to the last slash
             git commit -m "${category}/${name}: Update to latest ${branch}"
+
+            if [ "${commit}" = "push" ] ; then
+                git push
+            fi
         fi
     )
 
-    if [ "${commit}" = "true" ] then
+    if [[ "${commit}" =~ (commit|push) ]] ; then
         local submodule_path="$(echo "${ebuild_dir}" \
                                 | sed -n 's/\(coreos-overlay\|portage-stable\).*/\1/p')"
         local submodule="$(basename "${submodule_path}")"

--- a/ci-automation/util/update_cros_workon.sh
+++ b/ci-automation/util/update_cros_workon.sh
@@ -44,7 +44,7 @@ function update_cros_workon() {
         # We do this early so we error out before touching anything.
         if [ "${commit}" = "push" ] ; then
 
-            local ebuild_branch="$(git -C branch --show-current)"
+            local ebuild_branch="$(git branch --show-current)"
             if [ "${commit}" = "push" -a -z "${ebuild_branch}" ] ; then
                 # We're in headless mode, see if we can find a branch tip on origin
                 local sha="$(git rev-parse HEAD)"

--- a/ci-automation/util/update_cros_workon.sh
+++ b/ci-automation/util/update_cros_workon.sh
@@ -47,11 +47,11 @@ function update_cros_workon() {
         new_softlink="${name}-${version}-r${new_release}.ebuild"
         ln -s "${ebuild}" "${new_softlink}"
 
-        local repo="$(eval "$(grep -E '(CROS_WORKON_REPO|CROS_WORKON_PROJECT)' "${ebuild}")"
+        local repo="$(eval "$(grep -E '^\s*(CROS_WORKON_REPO|CROS_WORKON_PROJECT)=' "${ebuild}")"
                       echo $CROS_WORKON_REPO/$CROS_WORKON_PROJECT)"
         commit_id="$(git ls-remote "${repo}" "${branch}" | awk "/[[:space:]]${branch}/ {print \$1}")"
 
-        sed -i "s/CROS_WORKON_COMMIT.*/CROS_WORKON_COMMIT=\"${commit_id}\" # tip of branch ${branch} $(date)/" \
+        sed -i "s/CROS_WORKON_COMMIT=.*/CROS_WORKON_COMMIT=\"${commit_id}\" # tip of branch ${branch} $(date)/" \
                 "${ebuild}"
 
         rm "${softlink}"
@@ -61,7 +61,9 @@ function update_cros_workon() {
 
         if [ "${commit}" = "true" ] then
             git add .
-            git commit -m "${new_softlink}: Update ${name} to latest ${branch}"
+            local category="$(dirname "${PWD}")"
+            category="${category##*/}" # strip everything from the beginning to the last slash
+            git commit -m "${category}/${name}: Update to latest ${branch}"
         fi
     )
 

--- a/update_sdk_container_image
+++ b/update_sdk_container_image
@@ -8,7 +8,6 @@
 
 
 set -eu
-set -x
 
 cd $(dirname "$0")
 source sdk_lib/sdk_container_common.sh
@@ -97,5 +96,5 @@ done
 
 if ! $keep; then
     yell "Cleaning up intermediate container image"
-    $docker rmi flatcar-sdk-build:"${docker_vernum}"
+    $docker rmi "${sdk_build_image}"
 fi


### PR DESCRIPTION
This PR adds foundational functions to ci-automation for CI to update ebuilds which use `CROS_WORKON_COMMIT` and generate a new SDK container image with the changes (based on an existing SDK container).

Updating the SDK container (instead of building a new SDK from scratch) is meant to be used for patch-level changes which do not affect OS images built with the SDK. For example, an SDK's mantle suite (kola etc.) could be updated this way.

To update mantle to the latest commit in the default branch, higher-level CI would run:
1. `ci-automation/util/update_cros_workon.sh sdk_container/src/third_party/coreos-overlay/coreos-devel/mantle/ HEAD push`
2. `source ci-automation/sdk_container_update.sh`
3. `sdk_container_update`

`sdk_container_update` would create and push a tag to `scripts` when can then be used bu successive jobs, e.g. `test.sh`.