### PR TITLE
ci-automation: fix tap parser errors

### DIFF
--- a/ci-automation/tapfile_helper_lib.sh
+++ b/ci-automation/tapfile_helper_lib.sh
@@ -124,7 +124,7 @@ function tap_ingest_tapfile() {
                 else
                     echo -e "$line" \
                         | sed -e 's/^Error: "--- FAIL: /"/' -e 's/^[[:space:]]*//' \
-                              -e "s/[>\"']/_/g" -e 's/[[:space:]]/ /g' \
+                              -e "s/[>\\\"']/_/g" -e 's/[[:space:]]/ /g' \
                               -e 's/.\{200\}/&\n/g' \
                         >> "${error_message_file}"
                     continue
@@ -296,8 +296,8 @@ function tap_generate_report() {
                         WHERE t.case_id=c.id
                         AND c.name='${test_name}'
                         AND t.run='${run}';" | \
-                    sed 's/"/ /' | \
-                    awk '{print "      LINE " NR":" $0}'
+                    sed 's/"/ /g' | \
+                    awk '{print "      L" NR ": \"" $0 "\""}'
                 done
             fi
         fi


### PR DESCRIPTION
This change fixes and adds more string chars escaping in the test error debug output (`\` are removed and a bug in removing `"` is fixed), addressing a parser errof the CI encountered when ingesting TAP output.

Furthermore, line numbering is shortened, and test names have a spurious `-` prefix removed.