### PR TITLE
Fix and improve channel handling

### DIFF
--- a/ci-automation/image.sh
+++ b/ci-automation/image.sh
@@ -37,6 +37,9 @@ set -eu
 function image_build() {
     local arch="$1"
 
+    source sdk_lib/sdk_container_common.sh
+    local channel=""
+    channel="$(get_git_channel)"
     source ci-automation/ci_automation_common.sh
     init_submodules
 
@@ -58,7 +61,7 @@ function image_build() {
             mkdir -p "${CONTAINER_IMAGE_ROOT}"
     ./run_sdk_container -n "${image_container}" -C "${packages_image}" \
             -v "${vernum}" \
-            ./build_image --board="${arch}-usr" \
+            ./build_image --board="${arch}-usr" --group="${channel}" \
                           --output_root="${CONTAINER_IMAGE_ROOT}" \
                           --torcx_root="${CONTAINER_TORCX_ROOT}" prodtar container
 

--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -23,6 +23,7 @@ if [ "$@" != "" ] && [ "$@" != "*" ] && [ "$@" != "cl.update.payload" ]; then
 fi
 
 source ci-automation/ci_automation_common.sh
+source sdk_lib/sdk_container_common.sh
 
 mkdir -p "${work_dir}"
 cd "${work_dir}"
@@ -35,13 +36,10 @@ else
     copy_from_buildcache "images/${arch}/${vernum}/flatcar_test_update.gz" tmp/
 fi
 
-# Get last release tag (and filter out the alpha-3046.0.0 tag which was done without updating the submodule and thus refers a commit on main)
-PREV_TAG=$(git describe --tags --abbrev=0 | sed 's/alpha-3046.0.0//g')
-if [ "${PREV_TAG}" = "" ]; then
-    # For main we compare to last alpha release
+ON_CHANNEL="$(get_git_channel)"
+if [ "${ON_CHANNEL}" = "developer" ]; then
+    # For main/dev builds we compare to last alpha release
     ON_CHANNEL="alpha"
-else
-    ON_CHANNEL=$(echo "${PREV_TAG}" | cut -d "-" -f 1)
 fi
 if [ "${ON_CHANNEL}" = "lts" ]; then
     echo "Updating from previous LTS is not supported yet (needs creds), fallback to Stable"

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -133,20 +133,19 @@ set +x
 set +e
 echo "==================================================================="
 echo
-# Get last release tag (and filter out the alpha-3046.0.0 tag which was done without updating the submodule and thus refers a commit on main)
-PREV_TAG=$(git -C src/scripts describe --tags --abbrev=0 | sed 's/alpha-3046.0.0//g')
-if [ "${PREV_TAG}" = "" ]; then
-  # For main we compare to last alpha release
-  export CHANNEL_A="alpha"
-  export VERSION_A=$(curl -s -S -f -L "https://${CHANNEL_A}.release.flatcar-linux.net/${BOARD}/current/version.txt" | grep -m 1 "FLATCAR_VERSION=" | cut -d "=" -f 2)
+if [ "${GROUP}" != "developer" ]; then
+  export CHANNEL_A="${GROUP}"
 else
-  export CHANNEL_A=$(echo "${PREV_TAG}" | cut -d "-" -f 1)
-  export VERSION_A=$(echo "${PREV_TAG}" | cut -d "-" -f 2)
+  export CHANNEL_A="${CHANNEL_BASE}"
 fi
+
 if [ "${CHANNEL_A}" = "lts" ]; then
   echo "Comparing to LTS is not supported yet (needs creds)"
   exit 0
 fi
+
+export VERSION_A=$(curl -s -S -f -L "https://${CHANNEL_A}.release.flatcar-linux.net/${BOARD}/current/version.txt" | grep -m 1 "FLATCAR_VERSION=" | cut -d "=" -f 2)
+
 if [ "${GROUP}" = "developer" ]; then
   export CHANNEL_B="developer"
   export MODE_B="/developer/"

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -87,6 +87,25 @@ function build_id_from_version() {
 }
 # --
 
+# Get channel from a version string ("alpha-3244.0.1-nightly2" => "alpha")
+#
+function channel_from_version() {
+    local version="$1"
+    local channel=""
+
+    channel=$(echo "${version}" | cut -d - -f 1)
+    if [ "${channel}" != "alpha" ] && [ "${channel}" != "beta" ] && [ "${channel}" != "stable" ] && [ "${channel}" != "lts" ]; then
+        channel="developer"
+    fi
+    echo "${channel}"
+}
+# --
+
+function get_git_channel() {
+	channel_from_version "$(get_git_version)"
+}
+# --
+
 # extract the version number (w/o build ID) from a version string ("alpha-3244.0.1-nightly2" => "3244.0.1")
 #
 function vernum_from_version() {


### PR DESCRIPTION
- jenkins/images: find channel from base channel variable  
    Using the tags on the branch is not enough to find the channel we want
    to be the dev build be related to.
    Use the base channel variable which was introduced for this.
- ci-automation: set the channel from the git tag
    For now we had only "developer" images in the new pipeline.
    Based on the git tag like "alpha-1234.0.0" set the channel (group) for
    the image and also use this logic when finding the channel in the QEMU
    update test.

## How to use

Port to all channels

The first change fixes the package-diff comparison that sometimes failed (for dev builds and for release builds). The second is for being able to build a release image in the new pipeline (a first step towards making releases from it).

## Testing done

[ongoing](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5023/cldsv/) for jenkins/images.sh

[ongoing](http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/packages/945/cldsv/) for ci-automation group setting and qemu update test

