### PR TITLE
automation/test.sh: pass PARALLEL_TESTS to container

### DIFF
--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -137,7 +137,7 @@ function test_run() {
     __prepare_torcx "${arch}" "${vernum}" "${work_dir}"
 
     # Pass PARALLEL_TESTS to the container
-    if [ -n "${PARALLEL_TESTS}" ] ; then
+    if [ -n "${PARALLEL_TESTS-}" ] ; then
         echo "PARALLEL_TESTS=\"${PARALLEL_TESTS}\"" > sdk_container/.env
         echo "rm -f 'sdk_container/.env'" >> ./ci-cleanup.sh
     fi

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -38,6 +38,8 @@
 #      All positional arguments after the first 2 (see above) are tests / patterns of tests to run.
 #
 #   MAX_RETRIES. Environment variable. Number of re-runs to overcome transient failures. Defaults to 20.
+#   PARALLEL_TESTS. Environment variable. Number of test cases to run in parallel.
+#                   Default is image / vendor specific and defined in ci-automation/ci-config.env.
 #
 # OUTPUT:
 #
@@ -133,6 +135,12 @@ function test_run() {
 
     # Make the torcx artifacts available to test implementation
     __prepare_torcx "${arch}" "${vernum}" "${work_dir}"
+
+    # Pass PARALLEL_TESTS to the container
+    if [ -n "${PARALLEL_TESTS}" ] ; then
+        echo "PARALLEL_TESTS=\"${PARALLEL_TESTS}\"" > sdk_container/.env
+        echo "rm -f 'sdk_container/.env'" >> ./ci-cleanup.sh
+    fi
 
     local tap_merged_summary="results-${image}.tap"
     local tap_merged_detailed="results-${image}-detailed.tap"


### PR DESCRIPTION
Pass PARALLEL_TESTS to the SDK container if it is set before running tests. Since the tests are started in the container, we need to make available the variable inside the container.

Needs to be cherry-picked to flatcar-3033, flatcar-3139, and flatcar-3165.