### PR TITLE
ci-automation: set images as official based on version

### DIFF
--- a/ci-automation/image.sh
+++ b/ci-automation/image.sh
@@ -55,10 +55,22 @@ function image_build() {
     local image="flatcar-images-${arch}"
     local image_container="${image}-${docker_vernum}"
 
+    local official_arg=""
+    if is_official "${vernum}"; then
+            export COREOS_OFFICIAL=1
+            official_arg="--official"
+    else
+            export COREOS_OFFICIAL=0
+            official_arg="--noofficial"
+    fi
+
     # build image and store it in the container
     ./run_sdk_container -x ./ci-cleanup.sh -n "${image_container}" -C "${packages_image}" \
             -v "${vernum}" \
             mkdir -p "${CONTAINER_IMAGE_ROOT}"
+    ./run_sdk_container -n "${image_container}" -C "${packages_image}" \
+            -v "${vernum}" \
+            ./set_official --board="${arch}-usr" "${official_arg}"
     ./run_sdk_container -n "${image_container}" -C "${packages_image}" \
             -v "${vernum}" \
             ./build_image --board="${arch}-usr" --group="${channel}" \


### PR DESCRIPTION
The image needs to be set into official mode through a helper script
(see jenkins/images.sh) and the COREOS_OFFICIAL variable needs to be
set for prod_image_util.sh/build_image_util.sh/grub_install.sh.

## How to use

Pick for alpha, beta, stable

## Testing done

[passed](http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/packages/993/cldsv/) and `/usr/share/update_engine/update-payload-key.pub.pem` is present while `update-payload-key.key.pem` is absent on the image because coreos-au-key got rebuild in the image job with the flag "official"