### PR TITLE
ci-automation/tapfile_helper_lib: fix commiting last transaction

### DIFF
--- a/ci-automation/tapfile_helper_lib.sh
+++ b/ci-automation/tapfile_helper_lib.sh
@@ -160,10 +160,9 @@ function tap_ingest_tapfile() {
             fi
 
         done < "$tapfile"
+        SQL="${SQL}COMMIT;"
+        __sqlite3_wrapper "${SQL}"
     )
-
-    SQL="${SQL}COMMIT;"
-    __sqlite3_wrapper "${SQL}"
 }
 # --
 


### PR DESCRIPTION
# ci-automation/tapfile_helper_lib: fix commiting last transaction

Move the final db commit to inside the subshell. Since the while loop
runs inside a subshell, the SQL variable outside of the subshell is not
modified, and so the last contents of the SQL variable are dropped. This
shows up when the last couple test cases don't have an error message,
and simply append the transaction to 'SQL'. They are never written to
the db.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done
Before this commit: http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/test/228/console. Notice that a single job failed in run 1, and is retried indefinitely because in all other runs because it produces no output.

With this commit: http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/test/229/console

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
