### PR TITLE
ci-automation/tapfile_helper_lib.sh: only ASCII chars

### DIFF
--- a/ci-automation/tapfile_helper_lib.sh
+++ b/ci-automation/tapfile_helper_lib.sh
@@ -122,10 +122,12 @@ function tap_ingest_tapfile() {
                     in_error_message=false
                     has_error_message="true"
                 else
+                    # remove special characters and unicode. Jenkins TAP parser don't unicode.
                     echo -e "$line" \
-                        | sed -e 's/^Error: "--- FAIL: /"/' -e 's/^[[:space:]]*//' \
+                        | LC_ALL=C sed -e 's/^Error: "--- FAIL: /"/' -e 's/^[[:space:]]*//' \
                               -e "s/[>\\\"']/_/g" -e 's/[[:space:]]/ /g' \
                               -e 's/.\{200\}/&\n/g' \
+                              -e 's/[^\x00-\x7F]/?/g' \
                         >> "${error_message_file}"
                     continue
                 fi


### PR DESCRIPTION
This change removes all non-ASCII characters from test debug / error output when ingesting the output for inclusion in the TAP report. Jenkins TAP parser does not handle some unicode chars, leading to tap parser errors with e.g. Cilium output (which uses unicode).

Needs to be cherry-picked to flatcar-3033, flatcar-3139, and flatcar-3165.