### PR TITLE
jenkins/kola/aws: run tests on additional instance types

### DIFF
--- a/jenkins/kola/aws.sh
+++ b/jenkins/kola/aws.sh
@@ -49,6 +49,7 @@ cl_internet_included="$(set -o noglob; bin/kola list --platform=aws --filter ${K
 if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_internet_included}" != ""  ]]; then
   for INSTANCE in m4.2xlarge; do
     (
+    set +x
     OUTPUT=$(timeout --signal=SIGQUIT 6h bin/kola run \
     --parallel=8 \
     --basename="${NAME}" \

--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -48,6 +48,7 @@ cl_internet_included="$(set -o noglob; bin/kola list --platform=packet --filter 
 if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_internet_included}" != ""  ]]; then
   for INSTANCE in c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
     (
+    set +x
     OUTPUT=$(timeout --signal=SIGQUIT "${timeout}" bin/kola run \
     --basename="${NAME}" \
     --board="${BOARD}" \


### PR DESCRIPTION
There was a regression for an instance type which could have been
prevented by testing.
Add the same extended test logic used for Equinix Metal to AWS.

## How to use
Expected to fail due to https://github.com/flatcar-linux/Flatcar/issues/665

Port to all channels

## Testing done
[done](http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/aws/1240/console)
