### PR TITLE
jenkins/images: print kernel config changes

### DIFF
--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -162,6 +162,9 @@ echo
 echo "Image file changes, compared to ${CHANNEL_A} ${VERSION_A}:"
 FILE=flatcar_production_image_contents.txt FILESONLY=1 CUTKERNEL=1 ./package-diff "${VERSION_A}" "${FLATCAR_VERSION}"
 echo
+echo "Image kernel config changes, compared to ${CHANNEL_A} ${VERSION_A}:"
+FILE=flatcar_production_image_kernel_config.txt ./package-diff "${VERSION_A}" "${FLATCAR_VERSION}"
+echo
 echo "Image file size change (includes /boot, /usr and the default rootfs partitions), compared to ${CHANNEL_A} ${VERSION_A}:"
 FILE=flatcar_production_image_contents.txt CALCSIZE=1 ./package-diff "${VERSION_A}" "${FLATCAR_VERSION}"
 echo


### PR DESCRIPTION
Sometimes the Linux build system changes and results in unexpected
kernel config results.
Print changes in the kernel config as part of the image diff report.


## How to use

See output at end of image matrix job

Pick for all channels

## Testing done

None