### PR TITLE
Support split lib and lib64 layout

### DIFF
--- a/build_library/check_root
+++ b/build_library/check_root
@@ -106,6 +106,7 @@ USR_LINKS = ("/bin/", "/sbin/", "/lib/", "/lib32/", "/lib64/")
 IGNORE_SHEBANG = (
     "*/python[0-9].[0-9]/cgi.py",
     "*/usr/lib64/modules/*/source/scripts/*",
+    "*/usr/lib/modules/*/source/scripts/*",
     "*/usr/share/nova-agent/*/etc/gentoo/nova-agent",
     "*/tmp/*",
     "*/Documentation/*",

--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -62,6 +62,10 @@ CPE_NAME="cpe:2.3:o:${OS_ID}-linux:${OS_ID}_linux:${FLATCAR_VERSION}:*:*:*:*:*:*
 EOF
 sudo ln -sf "../usr/lib/os-release" "${ROOT_FS_DIR}/etc/os-release"
 sudo ln -sf "../../lib/os-release" "${ROOT_FS_DIR}/usr/share/flatcar/os-release"
+# Compat for split of lib64 into lib and lib64
+if [ ! -e "${ROOT_FS_DIR}/usr/lib64/os-release" ]; then
+  sudo ln -sf "../lib/os-release" "${ROOT_FS_DIR}/usr/lib64/os-release"
+fi
 
 # Create the defaults for the coreos configuration files in the usr directory
 sudo_clobber "${ROOT_FS_DIR}/usr/share/flatcar/release" <<EOF

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -133,6 +133,8 @@ set +x
 set +e
 echo "==================================================================="
 echo
+export BOARD_A="${BOARD}"
+export BOARD_B="${BOARD}"
 if [ "${GROUP}" != "developer" ]; then
   export CHANNEL_A="${GROUP}"
 else


### PR DESCRIPTION
## How to use

together with https://github.com/flatcar-linux/coreos-overlay/pull/1713

## Testing done
see linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ one in coreos-overlay