### PR TITLE
ci-automation/vendor-testing/qemu_update.sh: fix unbound

### DIFF
--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -59,9 +59,9 @@ bios="${QEMU_BIOS}"
 if [ "${arch}" = "arm64" ]; then
     bios="${QEMU_UEFI_BIOS}"
     if [ -f "${bios}" ] ; then
-        echo "++++ ${testscript}: Using existing ${work_dir}/${bios} ++++"
+        echo "++++ qemu_update.sh: Using existing ${work_dir}/${bios} ++++"
     else
-        echo "++++ ${testscript}: downloading ${bios} for ${vernum} (${arch}) ++++"
+        echo "++++ qemu_update.sh: downloading ${bios} for ${vernum} (${arch}) ++++"
         copy_from_buildcache "images/${arch}/${vernum}/${bios}" .
     fi
 fi


### PR DESCRIPTION
One-line fix to resolve
```
    ci-automation/vendor-testing/qemu_update.sh: line 64: testscript: unbound variable
```
error.

Should be cherry-picked to flatcar-3033, flatcar-3139, flatcar-3165.