### PR TITLE
ci-automation/tapfile_helper_lib.sh: remove non-printable ASCII

### DIFF
--- a/ci-automation/tapfile_helper_lib.sh
+++ b/ci-automation/tapfile_helper_lib.sh
@@ -127,7 +127,7 @@ function tap_ingest_tapfile() {
                         | LC_ALL=C sed -e 's/^Error: "--- FAIL: /"/' -e 's/^[[:space:]]*//' \
                               -e "s/[>\\\"']/_/g" -e 's/[[:space:]]/ /g' \
                               -e 's/.\{200\}/&\n/g' \
-                              -e 's/[^\x00-\x7F]/?/g' \
+                              -e 's/[^\x1F-\x7F]/?/g' \
                         >> "${error_message_file}"
                     continue
                 fi


### PR DESCRIPTION
Jenkins TAP file parser does not process non-printable ASCII characters but bails out. This change removes all ASCII < 0x1F, so non-printable characters are not included in the TAP report.

Fixes
```
   ...
    Caused by: unacceptable character '' (0x1B) special characters are not allowed
   ...
```