### PR TITLE
run_sdk_container: skip fetching image if custom_image is requested

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -108,8 +108,12 @@ if [ -z "$stat" ] ; then
 
     gpg_volumes=$(gnupg_ssh_gcloud_mount_opts)
 
-    source ci-automation/ci_automation_common.sh
-    docker_image_from_registry_or_buildcache "flatcar-sdk-${arch}" "${docker_sdk_vernum}"
+    if [ -z "$custom_image" ]; then
+	(
+            source ci-automation/ci_automation_common.sh
+            docker_image_from_registry_or_buildcache "flatcar-sdk-${arch}" "${docker_sdk_vernum}"
+	)
+    fi
 
     $docker create $tty -i \
        -v /dev:/dev \


### PR DESCRIPTION

# run_sdk_container: skip fetching image if custom_image is requested

In our CI most uses of run_sdk_container pass the '-C image' flag, which broke
with the last change, due to unbound docker_sdk_vernum variable. Skip fetching
the image when custom_image is passed.

Fixes #259

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
