### PR TITLE
ci-automation/test.sh: export PARALLEL_TESTS

### DIFF
--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -145,7 +145,7 @@ function test_run() {
 
     # Pass PARALLEL_TESTS to the container
     if [ -n "${PARALLEL_TESTS-}" ] ; then
-        echo "PARALLEL_TESTS=\"${PARALLEL_TESTS}\"" > sdk_container/.env
+        echo "export PARALLEL_TESTS=\"${PARALLEL_TESTS}\"" > sdk_container/.env
         echo "rm -f 'sdk_container/.env'" >> ./ci-cleanup.sh
     fi
 


### PR DESCRIPTION
Export PARALLEL_TESTS in the container's .env file to ensure it is passed to the vendor script.

Should be cherry-picked to all release branches (3033, 3139, and 3165/3185).