### PR TITLE
jenkins/kola/do: use gzipped image file

### DIFF
--- a/jenkins/kola/do.sh
+++ b/jenkins/kola/do.sh
@@ -9,11 +9,11 @@ set -o pipefail
 if [[ "${DOWNLOAD_ROOT}" == gs://flatcar-jenkins-private/* ]]; then
   echo "Fetching google/cloud-sdk"
   docker pull google/cloud-sdk > /dev/null
-  BUCKET_PATH="${DOWNLOAD_ROOT}/boards/${BOARD}/${FLATCAR_VERSION}/flatcar_production_digitalocean_image.bin.bz2"
+  BUCKET_PATH="${DOWNLOAD_ROOT}/boards/${BOARD}/${FLATCAR_VERSION}/flatcar_production_digitalocean_image.bin.gz"
   IMAGE_URL="$(docker run --rm --net=host -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}" google/cloud-sdk sh -c "python3 -m pip install pyopenssl > /dev/null; gsutil signurl -d 7d -r us ${GOOGLE_APPLICATION_CREDENTIALS} ${BUCKET_PATH} | grep -o 'https.*'")"
 else
   BASE_URL="https://bucket.release.flatcar-linux.net/$(echo $DOWNLOAD_ROOT | sed 's|gs://||g')/boards/${BOARD}/${FLATCAR_VERSION}"
-  IMAGE_URL="${BASE_URL}/flatcar_production_digitalocean_image.bin.bz2"
+  IMAGE_URL="${BASE_URL}/flatcar_production_digitalocean_image.bin.gz"
 fi
 
 bin/ore do create-image \


### PR DESCRIPTION
# jenkins/kola/do: use gzipped image file

The bzipped image file sometimes results in a timeout during decompression on
the remote side. Gzipped images are supposed to be better supported by
DigitalOcean, so use those.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
