### PR TITLE
ci-automation: use a single git tag and skip nightlies with no changes

### DIFF
--- a/ci-automation/README.md
+++ b/ci-automation/README.md
@@ -46,23 +46,23 @@ image_build amd64
    The resulting image will come in "amd64", "arm64", and "all" flavours, with support for respective OS target architectures. This step builds the Flatcar SDK container images published at ghcr.io/flatcar-linux.
 
 ```
-         .---------.                 .------------.          .--------.
-         | scripts |                 |     CI     |          |  Build |
-         |  repo   |                 | automation |          |  cache |
-         `---------´                 `------------´          `--------´
-              |                             |                     |
-              |                   "alpha-3449.0.0-dev23"          |
-              |                             |                     |
-              |                      _______v_______              |
-              +------- clone -----> ( SDK bootstrap )             |
-              |                      `-------------´              |
-              |<- tag: sdk-3499.0.0-dev23 -´|`--- sdk tarball --->|
-              |                             |                     |
-              |                      _______v_______              |
-              +--      clone     -> ( SDK container )             |
-              | sdk-3499.0.0-dev23   `-------------´              |
-              |                             |`- sdk container --->|
-              v                             v        image
+         .---------.                    .------------.          .--------.
+         | scripts |                    |     CI     |          |  Build |
+         |  repo   |                    | automation |          |  cache |
+         `---------´                    `------------´          `--------´
+              |                                |                     |
+              |                      "alpha-3449.0.0-dev23"          |
+              |                                |                     |
+              |                         _______v_______              |
+              +-------- clone -------> ( SDK bootstrap )             |
+              |                         `-------------´              |
+              |<- tag: alpha-3499.0.0-dev23 --´|`--- sdk tarball --->|
+              |                                |                     |
+              |                         _______v_______              |
+              +-------- clone -------> ( SDK container )             |
+              | alpha-3499.0.0-dev23    `-------------´              |
+              |                                |`- sdk container --->|
+              v                                v        image
                       continue to OS
                        image build
                             |


### PR DESCRIPTION
The pipeline created two tags if an SDK was built, one for the SDK and
one for the OS build (which was a free-standing tag or a local state
that was equivalent to the existing tag of the same name). The
nightlies created update commits on the main branch, even if no change
was done, and on the release branches we lacked these commits.

Create the release tag in the nightly SDK bootstrap already and reuse
it for the nightly OS build. Instead of local state, checkout the
existing tags explicitly. Extend the nightly update commit logic to
cover release branches and detect if we can skip building because no
changes were done.


## How to use
Needs Jenkins change to pass the regular version to the packages downstream job

Port to Stable/Beta/Alpha channels

## Testing done
Test case 1: simulating a nightly build of main with an existing tag and up-to-date submodules, expecting the build to be skipped (passed: it skipped the build)
Test case 2: simulating a nightly build of main with an existing tag but outdated submodules, expecting the build to happen and pass the new tag to the packages job (ongoing: it correctly starts the build, will check if it passes the right version to the packages job, [worked](http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/sdk/213/console))
Optional (since the same logic is used):Test case 3/4: simulating a nightly build of flatcar-3185 with the same scenarios as above, done [here](http://jenkins.infra.kinvolk.io:8080/job/_testing_/job/container-test/job/packages/1169/console) but without having it push to the branch because it wasn't simulating a nightly build (the coreos-overlay/portage-stable references didn't match)


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not needed