### PR TITLE
ci-automation/test.sh: remove PARALLEL_TESTS passing (move to CI)

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -33,6 +33,14 @@ CONTAINER_IMAGE_ROOT="/home/sdk/build/images"
 # Image / vendor tests settings
 #
 
+# NOTE that these settings are evaluated by the vendor-tests script inside the
+#  SDK container. To override, new values must be passed into the container.
+#  Use something like
+#    echo "export [VAR]=\"${[VALUE]}\\"" > sdk_container/.env
+#  in your CI to override, e.g.
+#    echo "export PARALLEL_TESTS=\"5\"" > sdk_container/.env
+#  to override the number of test cases to be run in parallel.
+
 # -- QEMU --
 
 QEMU_IMAGE_NAME="flatcar_production_image.bin"

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -143,12 +143,6 @@ function test_run() {
         -n "${container_name}" -C "${sdk_image}" -v "${vernum}" \
         sudo emerge mantle
 
-    # Pass PARALLEL_TESTS to the container
-    if [ -n "${PARALLEL_TESTS-}" ] ; then
-        echo "export PARALLEL_TESTS=\"${PARALLEL_TESTS}\"" > sdk_container/.env
-        echo "rm -f 'sdk_container/.env'" >> ./ci-cleanup.sh
-    fi
-
     local tap_merged_summary="results-${image}.tap"
     local tap_merged_detailed="results-${image}-detailed.tap"
     local retry=""


### PR DESCRIPTION
Remove passing of `PARALLEL_TESTS` because it really should be done by the CI. Add documentation in `ci-config.env` on how to pass variables into the SDK container.

Should be cherry-picked to 3033, 3139, 3185.