### PR TITLE
kola/gce: shrink hostname to be lower than 63 char

### DIFF
--- a/jenkins/kola/gce.sh
+++ b/jenkins/kola/gce.sh
@@ -13,9 +13,9 @@ if [[ "${OFFER}" != "basic" ]]; then
   OEM_SUFFIX="_${OFFER}"
 fi
 
-# Create a name that includes the OEM_SUFFIX,
+# Create a name that includes the OFFER,
 # but replace _ with -, as gcloud doesn't like it otherwise.
-OEMNAME="jenkins-${JOB_NAME##*/}${OEM_SUFFIX}-${BUILD_NUMBER}"
+OEMNAME="${OFFER}-${BUILD_NUMBER}"
 NAME=${OEMNAME//_/-}
 
 bin/ore gcloud create-image \


### PR DESCRIPTION
GCP Pro is failing because hostname is > 63 char:
```
Apr  5 19:52:27.522820 kubelet[1762]: E0405 19:52:27.522513    1762 kubelet_node_status.go:93] "Unable to register node with API server" err="Node \"jenkins-gce-pro-5-91a967ef5450cb932bc5.c.flatcar-212911.internal\" is invalid: metadata.labels: Invalid value: \"jenkins-gce-pro-5-91a967ef5450cb932bc5.c.flatcar-212911.internal\": must be no more than 63 characters" node="jenkins-gce-pro-5-91a967ef5450cb932bc5.c.flatcar-212911.internal"
```

Let's remove `jenkins` and `gce` from the hostname, these
information are not critical for debugging purposes.

Hostname should now looks like
"basic-5-91a967ef5450cb932bc5.c.flatcar-212911.internal" or
"pro-5-91a967ef5450cb932bc5.c.flatcar-212911.internal"

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

No changelog required.

- [ ] CI: http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/5361/cldsv/
