### PR TITLE
ci-automation/vms: rename equinix_metal to packet

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -60,6 +60,9 @@ function vm_build() {
     echo "docker container rm -f '${vms_container}'" >> ci-cleanup.sh
 
     for format; do
+        # keep compatibility with SDK scripts where "equinix_metal"
+        # remains unknown.
+        [ "${format}" = "equinix_metal" ] && format="packet"
         echo " ###################  VENDOR '${format}' ################### "
         ./run_sdk_container -n "${vms_container}" -C "${image_image}" \
             -v "${vernum}" \


### PR DESCRIPTION
this is required to keep "packet" in the SDK linguo while the user can
use "equinix_metal" term.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
