### PR TITLE
ci-automation/azure: Add initial container tests infra for Azure

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -121,7 +121,6 @@ AWS_PARALLEL="${PARALLEL_TESTS:-8}"
 # sdk_container/.env
 
 # -- Azure --
-: ${AZURE_HYPER_V_GENERATION:="V2"}
 : ${AZURE_IMAGE_NAME:="flatcar_production_azure_image.vhd"}
 : ${AZURE_MACHINE_SIZE:="Standard_D2s_v4"}
 : ${AZURE_MORE_MACHINE_SIZE:="Standard_D2s_v4"}

--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -119,3 +119,14 @@ VMWARE_ESX_PARALLEL="${PARALLEL_TESTS:-4}"
 AWS_PARALLEL="${PARALLEL_TESTS:-8}"
 # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY should come from
 # sdk_container/.env
+
+# -- Azure --
+: ${AZURE_HYPER_V_GENERATION:="V2"}
+: ${AZURE_IMAGE_NAME:="flatcar_production_azure_image.vhd"}
+: ${AZURE_MACHINE_SIZE:="Standard_D2s_v4"}
+: ${AZURE_MORE_MACHINE_SIZE:="Standard_D2s_v4"}
+: ${AZURE_USE_GALLERY:=""}
+: ${AZURE_USE_PRIVATE_IPS:=true}
+: ${AZURE_VNET_SUBNET_NAME:="jenkins-vnet-westeurope"}
+AZURE_PARALLEL="${PARALLEL_TESTS:-20}"
+AZURE_LOCATION="${AZURE_LOCATION:-westeurope}"

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -15,9 +15,10 @@ set -x
 source ci-automation/vendor_test.sh
 
 board="${CIA_ARCH}-usr"
-basename="ci-${CIA_VERNUM//+/-}"
+basename="ci-${CIA_VERNUM//+/-}-${CIA_ARCH}"
 azure_instance_type="${AZURE_MACHINE_SIZE}"
 azure_vnet_subnet_name="jenkins-vnet-${AZURE_LOCATION}"
+IS_AMD64=${CIA_ARCH//arm64/}
 
 azure_profile_config_file=''
 secret_to_file azure_profile_config_file "${AZURE_PROFILE}"
@@ -43,8 +44,12 @@ fi
 set -o noglob
 
 run_kola_tests() {
-    local instance_type="${1}"; shift
     local instance_tapfile="${1}"; shift
+    local hyperv_gen="v2"
+    if [ "${instance_type}" = "v1" ]; then
+        hyperv_gen="v1"
+        instance_type="${azure_instance_type}"
+    fi
 
     timeout --signal=SIGQUIT 20h \
 			kola run \
@@ -60,8 +65,8 @@ run_kola_tests() {
 			--torcx-manifest=${CIA_TORCX_MANIFEST} \
 			--tapfile="${instance_tapfile}" \
 			--azure-size=${instance_type} \
+			--azure-hyper-v-generation=${hyperv_gen} \
 			${AZURE_USE_GALLERY} \
-			${AZURE_HYPER_V_GENERATION:+--azure-hyper-v-generation=${AZURE_HYPER_V_GENERATION}} \
 			${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
 			${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
 			"${@}"
@@ -76,7 +81,7 @@ run_kola_tests_on_instances \
     "${azure_instance_type}" \
     "${CIA_TAPFILE}" \
     "${CIA_FIRST_RUN}" \
-    "" \
+    ${IS_AMD64:+v1} \
     '--' \
     '' \
     '--' \

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -44,6 +44,7 @@ fi
 set -o noglob
 
 run_kola_tests() {
+    local instance_type="${1}"; shift
     local instance_tapfile="${1}"; shift
     local hyperv_gen="v2"
     if [ "${instance_type}" = "v1" ]; then
@@ -52,24 +53,24 @@ run_kola_tests() {
     fi
 
     timeout --signal=SIGQUIT 20h \
-			kola run \
-			--board="${board}" \
-			--basename="${basename}" \
-			--parallel="${AZURE_PARALLEL}" \
-			--offering=basic \
-			--platform=azure \
-			--azure-image-file="${AZURE_IMAGE_NAME}" \
-			--azure-location="${AZURE_LOCATION}" \
-			--azure-profile="${azure_profile_config_file}" \
-			--azure-auth="${azure_auth_config_file}" \
-			--torcx-manifest=${CIA_TORCX_MANIFEST} \
-			--tapfile="${instance_tapfile}" \
-			--azure-size=${instance_type} \
-			--azure-hyper-v-generation=${hyperv_gen} \
-			${AZURE_USE_GALLERY} \
-			${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
-			${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
-			"${@}"
+      kola run \
+      --board="${board}" \
+      --basename="${basename}" \
+      --parallel="${AZURE_PARALLEL}" \
+      --offering=basic \
+      --platform=azure \
+      --azure-image-file="${AZURE_IMAGE_NAME}" \
+      --azure-location="${AZURE_LOCATION}" \
+      --azure-profile="${azure_profile_config_file}" \
+      --azure-auth="${azure_auth_config_file}" \
+      --torcx-manifest=${CIA_TORCX_MANIFEST} \
+      --tapfile="${instance_tapfile}" \
+      --azure-size=${instance_type} \
+      --azure-hyper-v-generation=${hyperv_gen} \
+      ${AZURE_USE_GALLERY} \
+      ${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
+      ${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
+      "${@}"
 }
 
 query_kola_tests() {

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -41,7 +41,6 @@ if [[ "${CIA_ARCH}" == "arm64" ]]; then
   AZURE_USE_GALLERY="--azure-use-gallery"
 fi
 
-set -o noglob
 
 run_kola_tests() {
     local instance_type="${1}"; shift

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -84,6 +84,6 @@ run_kola_tests_on_instances \
     "${CIA_FIRST_RUN}" \
     ${IS_AMD64:+v1} \
     '--' \
-    '' \
+    'cl.internet' \
     '--' \
     "${@}"

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Copyright (c) 2021 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+set -x
+
+# Test execution script for the qemu vendor image.
+# This script is supposed to run in the SDK container.
+
+# $@ now contains tests / test patterns to run
+
+source ci-automation/vendor_test.sh
+
+board="${CIA_ARCH}-usr"
+basename="ci-${CIA_VERNUM//+/-}"
+azure_instance_type="${AZURE_MACHINE_SIZE}"
+azure_vnet_subnet_name="jenkins-vnet-${AZURE_LOCATION}"
+
+azure_profile_config_file=''
+secret_to_file azure_profile_config_file "${AZURE_PROFILE}"
+azure_auth_config_file=''
+secret_to_file azure_auth_config_file "${AZURE_AUTH_CREDENTIALS}"
+
+testscript="$(basename "$0")"
+
+# Fetch the Azure image if not present
+if [ -f "${AZURE_IMAGE_NAME}" ] ; then
+    echo "++++ ${testscript}: Using existing ${work_dir}/${AZURE_IMAGE_NAME} for testing ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+else
+    echo "++++ ${testscript}: downloading ${AZURE_IMAGE_NAME} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+    copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${AZURE_IMAGE_NAME}.bz2" .
+    cp --sparse=always <(lbzcat "${AZURE_IMAGE_NAME}.bz2") "${AZURE_IMAGE_NAME}"
+    rm "${AZURE_IMAGE_NAME}.bz2"
+fi
+
+if [[ "${CIA_ARCH}" == "arm64" ]]; then
+  AZURE_USE_GALLERY="--azure-use-gallery"
+fi
+
+set -o noglob
+
+run_kola_tests() {
+    local instance_type="${1}"; shift
+    local instance_tapfile="${1}"; shift
+
+    timeout --signal=SIGQUIT 20h \
+			kola run \
+			--board="${board}" \
+			--basename="${basename}" \
+			--parallel="${AZURE_PARALLEL}" \
+			--offering=basic \
+			--platform=azure \
+			--azure-image-file="${AZURE_IMAGE_NAME}" \
+			--azure-location="${AZURE_LOCATION}" \
+			--azure-profile="${azure_profile_config_file}" \
+			--azure-auth="${azure_auth_config_file}" \
+			--torcx-manifest=${CIA_TORCX_MANIFEST} \
+			--tapfile="${instance_tapfile}" \
+			--azure-size=${instance_type} \
+			${AZURE_USE_GALLERY} \
+			${AZURE_HYPER_V_GENERATION:+--azure-hyper-v-generation=${AZURE_HYPER_V_GENERATION}} \
+			${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
+			${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
+			"${@}"
+}
+
+query_kola_tests() {
+    shift; # ignore the instance type
+    kola list --platform=azure --filter "${@}"
+}
+
+run_kola_tests_on_instances \
+    "${azure_instance_type}" \
+    "${CIA_TAPFILE}" \
+    "${CIA_FIRST_RUN}" \
+    "" \
+    '--' \
+    '' \
+    '--' \
+    "${@}"

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -5,7 +5,6 @@
 
 set -euo pipefail
 
-set -x
 
 # Test execution script for the qemu vendor image.
 # This script is supposed to run in the SDK container.


### PR DESCRIPTION
WIP PR

To test, I pass the Azure creds via the sdk_container/.env file, and current it fails with the issue

```
2022-04-19T10:10:15Z kola: creating flight for RunTests failed: Uploading blob failed: Parse footer field 'Cookie' failed: Invalid footer cookie data [0 0 0 0 0 0 0 0]
```


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
