### PR TITLE
Run CI container pipeline kola tests with the new mantle image

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -1,0 +1,54 @@
+name: Get the latest mantle release for branch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron:  '0 7 * * 1'
+
+jobs:
+  get-mantle-release:
+    strategy:
+      matrix:
+        branch: [main,alpha,beta,stable]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Figure out branch
+        id: figure-out-branch
+        run: |
+          if [ ${{ matrix.branch }} = "main" ]; then
+            echo ::set-output name=BRANCH::main
+          else
+            major=$(curl -sSL https://${{ matrix.branch }}.release.flatcar-linux.net/amd64-usr/current/version.txt | awk -F= '/FLATCAR_BUILD=/{ print $2 }')
+            echo ::set-output name=BRANCH::flatcar-${major}
+          fi
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
+      - name: Fetch latest mantle hash
+        id: fetch-latest-mantle
+        run: |
+          commit=$(git ls-remote  https://github.com/flatcar-linux/mantle refs/heads/flatcar-master | cut -f1)
+          echo ::set-output name=COMMIT::${commit}
+      - name: Try to apply patch
+        run: |
+          set -x
+          commit=${{ steps.fetch-latest-mantle.outputs.COMMIT }}
+          if ! grep -q "ghcr.io/flatcar-linux/mantle:git-${commit}" sdk_container/.repo/manifests/mantle-container; then
+            echo "ghcr.io/flatcar-linux/mantle:git-${commit}" > sdk_container/.repo/manifests/mantle-container
+            git add sdk_container/.repo/manifests/mantle-container
+          fi
+      - name: Create pull request for branch
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.figure-out-branch.outputs.BRANCH }}
+          branch: mantle-update-${{ steps.figure-out-branch.outputs.BRANCH }}
+          author: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          committer: Flatcar Buildbot <buildbot@flatcar-linux.org>
+          title: Upgrade mantle container image to latest HEAD in ${{ steps.figure-out-branch.outputs.BRANCH }}
+          commit-message: Update mantle container image to latest HEAD
+          delete-branch: true

--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -129,7 +129,7 @@ function copy_to_buildcache() {
     $sshcmd "${BUILDCACHE_USER}@${BUILDCACHE_SERVER}" \
         "mkdir -p ${remote_path}"
 
-    rsync -Pav -e "${sshcmd}" "$@" \
+    rsync --partial -a -e "${sshcmd}" "$@" \
         "${BUILDCACHE_USER}@${BUILDCACHE_SERVER}:${remote_path}"
 }
 # --

--- a/sdk_container/.repo/manifests/mantle-container
+++ b/sdk_container/.repo/manifests/mantle-container
@@ -1,0 +1,1 @@
+ghcr.io/flatcar-linux/mantle:git-cdf70a21b356e6ed6b1da0cb2bf57deeea8e48f7


### PR DESCRIPTION
The SDK container does not exist for arm64 and is quite heavy. We
currently also resort to a unconditional rebuilding of mantle inside
the SDK.
Use the new mantle container image to run kola tests, and pin its
version through a text file that gets updated by GitHub Actions.

## How to use

Port to flatcar-3139, flatcar-3185, flatcar-3200

## Testing done

- GitHub Action PRs were created as expected: https://github.com/pothos/scripts/pulls
- arm64 qemu(_update) tests passed on the arm64 Jenkins build executor
- amd64 qemu(_update) tests passed

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not needed