### PR TITLE
jenkins: add azure_gen2 to arm64 formats

### DIFF
--- a/jenkins/formats-arm64-usr.txt
+++ b/jenkins/formats-arm64-usr.txt
@@ -1,4 +1,5 @@
 ami_vmdk
+azure_gen2
 openstack
 openstack_mini
 packet


### PR DESCRIPTION
# jenkins: add azure_gen2 to arm64 formats

Azure ARM64 instances entered preview, so produce images for them regularly
with every release now. Flatcar has supported Azure ARM64 since the first
release with the 5.15 kernel, which was something like 3139.0.0.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
