### PR TITLE
Use gangue compiled from Jenkins

### DIFF
--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -56,7 +56,7 @@ enter() {
         bin/cork enter --bind-gpg-agent=false -- env \
             FLATCAR_DEV_BUILDS="${DOWNLOAD_ROOT}" \
             FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \
-            {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \
+            {FETCH,RESUME}COMMAND_GS="/mnt/host/source/bin/gangue get \
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"

--- a/jenkins/kola/dev-container.sh
+++ b/jenkins/kola/dev-container.sh
@@ -31,13 +31,14 @@ sudo systemd-nspawn $PIPEARG \
     --bind-ro="$PWD/flatcar_production_image_kernel_config.txt:/boot/config" \
     --bind-ro="${GOOGLE_APPLICATION_CREDENTIALS}:/opt/credentials.json" \
     --bind-ro="$PWD/verify.asc:/opt/verify.asc" \
+    --bind-ro="$PWD/bin/gangue:/opt/bin/gangue" \
     --image=flatcar_developer_container.bin \
     --machine=flatcar-developer-container-$(uuidgen) \
     --tmpfs=/usr/src \
     --tmpfs=/var/tmp \
     /bin/bash -eux << 'EOF'
 export PORTAGE_BINHOST="${PORTAGE_BINHOST}"
-export {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get --json-key=/opt/credentials.json --verify=true /opt/verify.asc \"\${URI}\" \"\${DISTDIR}/\${FILE}\""
+export {FETCH,RESUME}COMMAND_GS="/opt/bin/gangue get --json-key=/opt/credentials.json --verify=true /opt/verify.asc \"\${URI}\" \"\${DISTDIR}/\${FILE}\""
 emerge-gitclone
 . /usr/share/coreos/release
 emerge -gv coreos-sources

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -60,7 +60,7 @@ enter() {
         bin/cork enter --bind-gpg-agent=false -- env \
             FLATCAR_DEV_BUILDS="${DOWNLOAD_ROOT}" \
             FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \
-            {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \
+            {FETCH,RESUME}COMMAND_GS="/mnt/host/source/bin/gangue get \
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"

--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -72,7 +72,7 @@ gpg --import "${GPG_SECRET_KEY_FILE}"
 sudo rm -rf src/build
 
 # Fetch DIGEST to prevent re-downloading the same SDK tarball
-enter gangue get --verify-key /opt/verify.asc --json-key /etc/portage/gangue.json "${DOWNLOAD_ROOT_SDK}/amd64/${FLATCAR_SDK_VERSION}/flatcar-sdk-amd64-${FLATCAR_SDK_VERSION}.tar.bz2.DIGESTS" /mnt/host/source/.cache/sdks/
+enter /mnt/host/source/bin/gangue get --verify-key /opt/verify.asc --json-key /etc/portage/gangue.json "${DOWNLOAD_ROOT_SDK}/amd64/${FLATCAR_SDK_VERSION}/flatcar-sdk-amd64-${FLATCAR_SDK_VERSION}.tar.bz2.DIGESTS" /mnt/host/source/.cache/sdks/
 
 enter sudo \
     FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \

--- a/jenkins/toolchains.sh
+++ b/jenkins/toolchains.sh
@@ -52,7 +52,7 @@ enter() {
   bin/cork enter --bind-gpg-agent=false -- env \
       FLATCAR_DEV_BUILDS="${DOWNLOAD_ROOT}" \
       FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \
-      {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \
+      {FETCH,RESUME}COMMAND_GS="/mnt/host/source/bin/gangue get \
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
       "$@"
@@ -66,7 +66,7 @@ source .repo/manifests/version.txt
 export FLATCAR_BUILD_ID
 
 # Fetch DIGEST to prevent re-downloading the same SDK tarball
-enter gangue get --verify-key /opt/verify.asc --json-key /etc/portage/gangue.json "${DOWNLOAD_ROOT_SDK}/amd64/${FLATCAR_SDK_VERSION}/flatcar-sdk-amd64-${FLATCAR_SDK_VERSION}.tar.bz2.DIGESTS" /mnt/host/source/.cache/sdks/
+enter /mnt/host/source/bin/gangue get --verify-key /opt/verify.asc --json-key /etc/portage/gangue.json "${DOWNLOAD_ROOT_SDK}/amd64/${FLATCAR_SDK_VERSION}/flatcar-sdk-amd64-${FLATCAR_SDK_VERSION}.tar.bz2.DIGESTS" /mnt/host/source/.cache/sdks/
 
 script update_chroot \
     --toolchain_boards="${BOARD}" --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}" --setuponly

--- a/jenkins/vms.sh
+++ b/jenkins/vms.sh
@@ -56,7 +56,7 @@ enter() {
         bin/cork enter --bind-gpg-agent=false -- env \
             FLATCAR_DEV_BUILDS="${GS_DEVEL_ROOT}" \
             FLATCAR_DEV_BUILDS_SDK="${DOWNLOAD_ROOT_SDK}" \
-            {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get \
+            {FETCH,RESUME}COMMAND_GS="/mnt/host/source/bin/gangue get \
 --json-key=/etc/portage/gangue.json $verify_key \
 "'"${URI}" "${DISTDIR}/${FILE}"' \
             "$@"


### PR DESCRIPTION
These scripts happened to use the copy of gangue in the SDK which isn't
expected because it should use the binaries complied by Jenkins.


## How to use

pick for all channels

Goes with https://github.com/flatcar-linux/coreos-overlay/pull/1827

## Testing done

see linked PR

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not needed