### PR TITLE
build_library/toolchain_util: set binutils to the latest version

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -363,6 +363,7 @@ install_cross_toolchain() {
     fi
 
     # Setup environment and wrappers for our shiny new toolchain
+    binutils_set_latest_profile "${cross_chost}"
     gcc_set_latest_profile "${cross_chost}"
     $sudo CC_QUIET=1 sysroot-config --install-links "${cross_chost}"
 }
@@ -431,6 +432,23 @@ install_cross_rust() {
     fi
 }
 
+# Update to the latest binutils profile for a given CHOST if required
+# Usage: binutils_set_latest_profile chost
+binutils_set_latest_profile() {
+    local latest="$@-latest"
+    if [[ -z "${latest}" ]]; then
+        echo "Failed to detect latest binutils profile for $1" >&2
+        return 1
+    fi
+
+    # may be called from either catalyst (root) or upgrade_chroot (user)
+    local sudo="env"
+    if [[ $(id -u) -ne 0 ]]; then
+        sudo="sudo -E"
+    fi
+
+    $sudo binutils-config "${latest}"
+}
 
 # Get the latest GCC profile for a given CHOST
 # The extra flag can be blank, hardenednopie, and so on. See gcc-config -l


### PR DESCRIPTION
# build_library/toolchain_util: set binutils to the latest version

This was already being done for gcc but not for binutils. Binutils is
also slotted and when we run the sdk (stage3/stage4) job in the CI, the
seed sdk already contains crossdev packages that we may want to update.

- [ ] https://github.com/flatcar-linux/coreos-overlay/pull/1838

## How to use

Test together with coreos-overlay#1838, requires at least a stage4 bootstrap.

## Testing done

Still testing.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
