### PR TITLE
[WIP] Vendor test for VMware

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -95,3 +95,10 @@ GCE_PARALLEL="${PARALLEL_TESTS:-4}"
 DIGITALOCEAN_PARALLEL="${PARALLEL_TESTS:-8}"
 # DIGITALOCEAN_TOKEN_JSON env var is used for credentials, and should
 # come from sdk_container/.env. It must be base64-encoded.
+
+# -- VMware ESX --
+
+: ${VMWARE_ESX_IMAGE_NAME:='flatcar_production_vmware_ova.ova'}
+VMWARE_ESX_PARALLEL="${PARALLEL_TESTS:-4}"
+# VMWARE_ESX_CREDS should come from sdk_container/.env and must be
+# base64-encoded.

--- a/ci-automation/vendor-testing/vmware.sh
+++ b/ci-automation/vendor-testing/vmware.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Copyright (c) 2022 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for the VMware ESX vendor image.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+# We never ran VMware ESX on arm64, so for now fail it as an
+# unsupported option.
+if [[ "${CIA_ARCH}" == "arm64" ]]; then
+    echo "1..1" > "${CIA_TAPFILE}"
+    echo "not ok - all qemu tests" >> "${CIA_TAPFILE}"
+    echo "  ---" >> "${CIA_TAPFILE}"
+    echo "  ERROR: ARM64 tests not supported on VMware ESX." | tee -a "${CIA_TAPFILE}"
+    echo "  ..." >> "${CIA_TAPFILE}"
+    break_retest_cycle
+    exit 1
+fi
+
+# Fetch image if not present.
+if [ -f "${VMWARE_ESX_IMAGE_NAME}" ] ; then
+    echo "++++ ${CIA_TESTSCRIPT}: Using existing ${work_dir}/${VMWARE_ESX_IMAGE_NAME} for testing ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+else
+    echo "++++ ${CIA_TESTSCRIPT}: downloading ${VMWARE_ESX_IMAGE_NAME} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+    copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${VMWARE_ESX_IMAGE_NAME}" .
+fi
+
+config_file=''
+secret_to_file config_file "${VMWARE_ESX_CREDS}"
+
+# If we are using static IPs, then delete every VM that is running
+# because we'll use all available spots. This is to avoid entering a
+# broken state if there are some left-over VMs from manual usage or a
+# forcefully terminated job.
+#
+# The assumption here is that we can do it without any interference
+# with other CI Vms, because we have acquired a resource lock to those
+# VMs.
+static_ips="$(jq '.["default"]["static_ips"]' "${config_file}")"
+if [[ "${static_ips}" -ne 0 ]]; then
+    ore esx --esx-config-file "${config_file}" remove-vms || :
+fi
+
+kola_test_basename="ci-${CIA_VERNUM//+/-}"
+
+trap 'ore esx --esx-config-file "${config_file}" remove-vms \
+    --pattern "${kola_test_basename}*" || :' EXIT
+
+set -x
+
+sudo timeout --signal=SIGQUIT 2h kola run \
+    --board="${CIA_ARCH}-usr" \
+    --basename="${kola_test_basename}" \
+    --channel="${CIA_CHANNEL}" \
+    --platform=esx \
+    --tapfile="${CIA_TAPFILE}" \
+    --parallel="${VMWARE_ESX_PARALLEL}" \
+    --torcx-manifest="${CIA_TORCX_MANIFEST}" \
+    --esx-config-file "${config_file}" \
+    --esx-ova-path "${VMWARE_ESX_IMAGE_NAME}" \
+    "${@}"
+
+set +x


### PR DESCRIPTION
This is to close https://github.com/flatcar-linux/Flatcar/issues/672.

~Does not work, feel free to pick it up.~ To test:

- Prepare the config file for kola. It's the secret sauce. It looks more or less like the following:

```json
{
        "default": {
                "user": "USERNAME",
                "password": "PASSWORD",
                "server": "IP_ADDRESS",
                "static_ips": NUMBER,
                "first_static_ip": "IP_ADDRESS",
                "first_static_ip_private": "IP_ADDRESS",
                "gateway": "IP_ADDRESS",
                "gateway_private": "IP_ADDRESS",
                "subnet_size": NUMBER
        }
}
```
- Encode the config file with base64 and put it into `sdk_container/.env` (like `export VMWARE_ESX_CREDS=<BASE64_ENCODED_CONFIG>`).
- From `<SCRIPTS_REPO>` directory do:
  - `bash` (this is to avoid losing a bash session and a tab in terminal emulator due to any failure and exit because of `set -e` done in the following step)
  - `. ci-automation/test.sh`
  - `test_run amd64 vmware cl.internet`
