### PR TITLE
CI: Support comparing to current LTS and updating from it

### DIFF
--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -41,10 +41,6 @@ if [ "${ON_CHANNEL}" = "developer" ]; then
     # For main/dev builds we compare to last alpha release
     ON_CHANNEL="alpha"
 fi
-if [ "${ON_CHANNEL}" = "lts" ]; then
-    echo "Updating from previous LTS is not supported yet (needs creds), fallback to Stable"
-    ON_CHANNEL="stable"
-fi
 if [ -f tmp/flatcar_production_image_previous.bin ] ; then
     echo "++++ QEMU test: Using existing ${work_dir}/tmp/flatcar_production_image_previous.bin for testing update to ${vernum} (${arch}) from previous ${ON_CHANNEL} ++++"
 else

--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -141,11 +141,6 @@ else
   export CHANNEL_A="${CHANNEL_BASE}"
 fi
 
-if [ "${CHANNEL_A}" = "lts" ]; then
-  echo "Comparing to LTS is not supported yet (needs creds)"
-  exit 0
-fi
-
 export VERSION_A=$(curl -s -S -f -L "https://${CHANNEL_A}.release.flatcar-linux.net/${BOARD}/current/version.txt" | grep -m 1 "FLATCAR_VERSION=" | cut -d "=" -f 2)
 
 if [ "${GROUP}" = "developer" ]; then


### PR DESCRIPTION
When the restriction that the CI can't access the LTS release is gone
we can support to run the image comparison and the kola update test.


## How to use


## Testing done

TODO
