### PR TITLE
jenkins/kola/qemu.sh: create missing folders

### DIFF
--- a/jenkins/kola/qemu.sh
+++ b/jenkins/kola/qemu.sh
@@ -50,7 +50,7 @@ bin/cork download-image \
 enter lbunzip2 -k -f /mnt/host/source/tmp/flatcar_production_image.bin.bz2
 
 # create folder to handle case where arm64 is missing
-sudo mkdir -p chroot/usr/lib/kola/arm64
+sudo mkdir -p chroot/usr/lib/kola/{arm64,amd64}
 # copy all of the latest mantle binaries into the chroot
 sudo cp -t chroot/usr/lib/kola/arm64 bin/arm64/*
 sudo cp -t chroot/usr/lib/kola/amd64 bin/amd64/*


### PR DESCRIPTION
This ports a similar change from "main" to create the directory for
amd64 if it doesn't exist because mantle is not installed in the SDK.


## How to use


## Testing done

[started](http://192.168.42.7:8080/job/os/job/manifest/5510/cldsv/)
