### PR TITLE
Remove unused image variants

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -8,9 +8,7 @@
 VALID_IMG_TYPES=(
     ami
     ami_vmdk
-    ami_vmdk_pro
     azure
-    azure_pro
     brightbox
     cloudsigma
     cloudstack
@@ -18,7 +16,6 @@ VALID_IMG_TYPES=(
     digitalocean
     exoscale
     gce
-    gce_pro
     hyperv
     interoute
     iso
@@ -214,10 +211,6 @@ IMG_ami_OEM_USE=ec2
 IMG_ami_vmdk_DISK_FORMAT=vmdk_stream
 IMG_ami_vmdk_OEM_PACKAGE=oem-ec2-compat
 IMG_ami_vmdk_OEM_USE=ec2
-# AWS Pro
-IMG_ami_vmdk_pro_DISK_FORMAT=vmdk_stream
-IMG_ami_vmdk_pro_OEM_PACKAGE=oem-ec2-compat
-IMG_ami_vmdk_pro_OEM_USE=ec2
 
 ## openstack, supports ec2's metadata format so use oem-ec2-compat
 IMG_openstack_DISK_FORMAT=qcow2
@@ -254,12 +247,6 @@ IMG_gce_CONF_FORMAT=gce
 IMG_gce_OEM_PACKAGE=oem-gce
 IMG_gce_OEM_ACI=gce
 
-## gce pro, image tarball
-IMG_gce_pro_DISK_LAYOUT=vm
-IMG_gce_pro_CONF_FORMAT=gce
-IMG_gce_pro_OEM_PACKAGE=oem-gce
-IMG_gce_pro_OEM_ACI=gce
-
 ## rackspace
 IMG_rackspace_OEM_PACKAGE=oem-rackspace
 IMG_rackspace_vhd_DISK_FORMAT=vhd
@@ -286,11 +273,6 @@ IMG_exoscale_OEM_PACKAGE=oem-exoscale
 IMG_azure_DISK_FORMAT=vhd_fixed
 IMG_azure_DISK_LAYOUT=azure
 IMG_azure_OEM_PACKAGE=oem-azure
-
-## azure pro
-IMG_azure_pro_DISK_FORMAT=vhd_fixed
-IMG_azure_pro_DISK_LAYOUT=azure
-IMG_azure_pro_OEM_PACKAGE=oem-azure
 
 ## hyper-v
 IMG_hyperv_DISK_FORMAT=vhd

--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -1,11 +1,8 @@
 ami
 ami_vmdk
-ami_vmdk_pro
 azure
 azure_gen2
-azure_pro
 gce
-gce_pro
 iso
 pxe
 qemu


### PR DESCRIPTION
There is no difference anymore between the regular and Pro images.
Remove the definitions and stop building extra images.

## How to use

Backport down to flatcar-3033

## Testing done

none

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not needed because the images weren't consumed directly but through the Marketplace offers which use the regular image now