### PR TITLE
jenkins/kola/packet: try to reduce test time by increasing parallelism

### DIFF
--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -4,7 +4,8 @@ set -ex
 # JOB_NAME will not fit within the character limit
 NAME="jenkins-${BUILD_NUMBER}"
 
-timeout=8h
+# same as the GC timeout
+timeout=6h
 
 set -o pipefail
 
@@ -33,14 +34,11 @@ fi
 # for PXE booting.
 # We override `PARALLEL_TESTS`, because kola run with PARALLEL_TESTS >= 4 causes the
 # tests to provision >= 12 ARM servers at the same time. As the da11 region does not
-# have that many free ARM servers, the whole tests will fail. With PARALLEL_TESTS=2
-# the total number of servers stays < 10.
-# In addition, we override `timeout` to 10 hours, because it takes more than 8 hours
-# to run all tests only with 2 tests in parallel.
+# have that many free ARM servers, the whole tests will fail. With PARALLEL_TESTS=3
+# the total number of servers stays <= 9.
 if [[ "${BOARD}" == "arm64-usr" ]]; then
   PACKET_REGION="DA"
-  PARALLEL_TESTS="2"
-  timeout=15h
+  PARALLEL_TESTS="3"
 fi
 
 # Run the cl.internet test on multiple machine types only if it should run in general


### PR DESCRIPTION
With the limit of 2 parallel tests, meaning 6 machines, the test time
is ~10 hours which is longer than the GC time. It seems that the
regional capacity is not so limited at the moment and we can try to
increase the number of machines.
Adjust the timeout to reflect the GC time and increase the parallel
tests to 3, meaning 9 machines.


## How to use

pick for all channels

## Testing done

none
