### PR TITLE
.github: Update LTS mantle reference

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -11,7 +11,7 @@ jobs:
   get-mantle-release:
     strategy:
       matrix:
-        branch: [main,alpha,beta,stable]
+        branch: [main,alpha,beta,stable,lts]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The new LTS release will use the mantle container image.
Add automation to keep it up to date.

## How to use
Merge when LTS 2022 is released

## Testing done

