### PR TITLE
update_sdk_container_image: work around sandbox permission errors

### DIFF
--- a/sdk_lib/Dockerfile.sdk-update
+++ b/sdk_lib/Dockerfile.sdk-update
@@ -4,8 +4,18 @@ FROM ${BASE}
 COPY --chown=sdk:sdk sdk_container/ /mnt/host/source
 COPY --chown=sdk:sdk . /mnt/host/source/src/scripts
 
+# Disable all sandboxing for SDK updates since some core packages
+#  (like GO) fail to build from a permission error otherwise.
+RUN cp /home/sdk/.bashrc /home/sdk/.bashrc.bak
+RUN echo 'export FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' \
+        >> /home/sdk/.bashrc
+
 RUN chown sdk:sdk /mnt/host/source
 RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
 
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="arm64-usr" --regen_configs
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="amd64-usr" --regen_configs
+
+# Restore original .bashrc to remove sandbox disablement
+RUN mv /home/sdk/.bashrc.bak /home/sdk/.bashrc
+RUN chown sdk:sdk /home/sdk/.bashrc

--- a/update_sdk_container_image
+++ b/update_sdk_container_image
@@ -8,7 +8,6 @@
 
 
 set -eu
-set -x
 
 cd $(dirname "$0")
 source sdk_lib/sdk_container_common.sh


### PR DESCRIPTION
This change temporarily disables the Gentoo sandbox when updating the SDK to work around sandbox permission errors some pakage builds (like e.g. GO) run into.

Fixes e.g.
```
Building Go cmd/dist using /usr/lib/go-bootstrap. (go1.5.3 linux/amd64)
 * /var/tmp/portage/sys-apps/sandbox-2.12/work/sandbox-2.12/libsandbox/trace.c:do_peekstr():125: failure (Operation not permitted):
 * ISE:do_peekstr:process_vm_readv(6863, 0x00007ffe4a502180{0x00007f01abd3e010, 0x570}, 1, 0x00007ffe4a502190{0x000000c820012a90, 0x570}, 1, 0) failed: Operation not permitted
 * ERROR: dev-lang/go-1.17.8::coreos failed (compile phase):
```

Needs cherry-picking to flatcar-3033, flatcar-3139, flatcar-3185, flatcar-3200, and flatcar-32227.