### PR TITLE
ci-automation: Push version file early

### DIFF
--- a/ci-automation/packages.sh
+++ b/ci-automation/packages.sh
@@ -122,6 +122,13 @@ function packages_build() {
     local docker_vernum="$(vernum_to_docker_image_version "${vernum}")"
     local packages_container="flatcar-packages-${arch}-${docker_vernum}"
 
+    # Create version file
+    (
+      source sdk_lib/sdk_container_common.sh
+      create_versionfile "$sdk_version" "$version"
+    )
+    update_and_push_version "${version}" "${push_branch}"
+
     # Build packages; store packages and torcx output in container
     ./run_sdk_container -x ./ci-cleanup.sh -n "${packages_container}" -v "${version}" \
         -C "${sdk_image}" \
@@ -154,7 +161,5 @@ function packages_build() {
         "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json"
     copy_to_buildcache "images/${arch}/${vernum}/torcx" \
         "${torcx_tmp}/torcx/pkgs/${arch}-usr/docker/"*/*.torcx.tgz
-
-    update_and_push_version "${version}" "${push_branch}"
 }
 # --

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -100,18 +100,20 @@ function sdk_bootstrap() {
     local vernum="${version#*-}" # remove alpha-,beta-,stable-,lts- version tag
     local git_vernum="${vernum}"
 
-    # This will update FLATCAR_VERSION[_ID] and BUILD_ID in versionfile
+    # Update FLATCAR_VERSION[_ID], BUILD_ID, and SDK in versionfile
+    (
+      source sdk_lib/sdk_container_common.sh
+      create_versionfile "${vernum}"
+    )
+    update_and_push_version "${version}" "${push_branch}"
+
     ./bootstrap_sdk_container -x ./ci-cleanup.sh "${seed_version}" "${vernum}"
 
     # push SDK tarball to buildcache
-    source sdk_container/.repo/manifests/version.txt
-    local vernum="${FLATCAR_SDK_VERSION}"
     local dest_tarball="flatcar-sdk-${ARCH}-${vernum}.tar.bz2"
 
     cd "__build__/images/catalyst/builds/flatcar-sdk"
     copy_to_buildcache "sdk/${ARCH}/${vernum}" "${dest_tarball}"*
     cd -
-
-    update_and_push_version "${version}" "${push_branch}"
 }
 # --


### PR DESCRIPTION
When a nightly build is started that pushes the version file to the
branch it was doing so only at the end of the build, causing the push
to fail if something else got merged in between.
Push the version file early by generating it the same way it would be
generated by the run_sdk_container/bootstrap_sdk_container scripts.
In the case of the SDK the version file gets the same version for the
OS and the SDK and a few commands were removed. Note that the scripts
will still rewrite the file but it should be a no-op.

Fixes https://github.com/flatcar-linux/Flatcar/issues/723

## How to use

Observe that a nightly build pushes the expected values in the version file to the branch at the start of the build. One case is the SDK job, the other the packages job.

## Testing done

TODO