### PR TITLE
jenkins: don't upload to private LTS/Pro bucket any longer

### DIFF
--- a/jenkins/prerelease/azure.sh
+++ b/jenkins/prerelease/azure.sh
@@ -4,7 +4,7 @@ set -ex
 AZURE_CATEGORY_OPT=""
 if [[ "${IS_NON_SPONSORED}" == true ]]
 then
-  AZURE_CATEGORY_OPT="--azure-category=pro --private"
+  AZURE_CATEGORY_OPT="--azure-category=pro"
 fi
 
 rm -f images.json

--- a/jenkins/vms.sh
+++ b/jenkins/vms.sh
@@ -91,15 +91,6 @@ then
   FORMATS="${FORMAT}"
 fi
 for FORMAT in ${FORMATS}; do
-  # If the format variable ends with _pro it's a Flatcar Pro image and it should
-  # be uploaded to the private bucket.
-  PRIVATE_UPLOAD_OPT=""
-  if [[ -z "${FORMAT##*_pro}" ]]
-  then
-    PRIVATE_UPLOAD_OPT="--private"
-    UPLOAD_ROOT=${UPLOAD_PRIVATE_ROOT}
-  fi
-
   script image_to_vm.sh \
     --board="${BOARD}" \
     --format="${FORMAT}" \
@@ -111,6 +102,5 @@ for FORMAT in ${FORMATS}; do
     --sign_digests="${SIGNING_USER}" \
     --download_root="${DOWNLOAD_ROOT}" \
     --upload_root="${UPLOAD_ROOT}" \
-    --upload \
-    ${PRIVATE_UPLOAD_OPT}
+    --upload
 done


### PR DESCRIPTION
With the LTS/Pro features public, we can use the public bucket to upload
the artifacts instead of the private one

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>

Related to #335 

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
