### PR TITLE
run_sdk_container: Workaround for write-protected /etc/hosts bind-mount

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -143,4 +143,7 @@ if [ "$stat" != "Up" ] ; then
     $docker start "$name"
 fi
 
+# Workaround: The SDK expects to be able to write to /etc/hosts
+$docker exec "$name" sh -c 'cp /etc/hosts /etc/hosts2; umount /etc/hosts ; mv /etc/hosts2 /etc/hosts'
+
 $docker exec $tty -i "$name" /home/sdk/sdk_entry.sh "$@"


### PR DESCRIPTION
The baselayout package wants to manage the /etc/hosts file and thus
fails to emerge in the SDK container. One would have to build a new
SDK container instead.
To unblock the LTS 3033.3.1 release we can add a workaround to make the
SDK container environment more similar to how cork worked by removing
the /etc/hosts bind mount. This action has to be added to
run_sdk_container instead of sdk_lib/sdk_entry.sh because the existing
SDK's copy of sdk_lib/sdk_entry.sh won't have the change.


## How to use

With this change we don't need to build a new SDK for the LTS 3033.3.1 release.

## Testing done

TODO: Run the 3033.0.0 SDK container and emerge the new baselayout package in the `flatcar-3033` branch.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
↑ not really user facing, not needed