### PR TITLE
jenkins/kola/azure|packet.sh: Remove hardcoded arm64 parallel test limit and align the timeout with the GC duration

### DIFF
--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -50,7 +50,8 @@ run_kola_tests() {
         instance_type="${azure_instance_type}"
     fi
 
-    timeout --signal=SIGQUIT 20h \
+    # Align timeout with ore azure gc --duration parameter
+    timeout --signal=SIGQUIT 6h \
       kola run \
       --board="${board}" \
       --basename="${basename}" \

--- a/jenkins/kola/azure.sh
+++ b/jenkins/kola/azure.sh
@@ -32,7 +32,8 @@ fi
 
 # Do not expand the kola test patterns globs
 set -o noglob
-timeout --signal=SIGQUIT 20h bin/kola run \
+# Align timeout with ore azure gc --duration parameter
+timeout --signal=SIGQUIT 6h bin/kola run \
     --parallel="${PARALLEL}" \
     --basename="${NAME}" \
     --board="${BOARD}" \

--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -32,13 +32,8 @@ fi
 # so we override the `PACKET_REGION` to `Dallas` since it's available in this region.
 # We do not override `PACKET_REGION` for both board on top level because we need to keep proximity
 # for PXE booting.
-# We override `PARALLEL_TESTS`, because kola run with PARALLEL_TESTS >= 4 causes the
-# tests to provision >= 12 ARM servers at the same time. As the da11 region does not
-# have that many free ARM servers, the whole tests will fail. With PARALLEL_TESTS=3
-# the total number of servers stays <= 9.
 if [[ "${BOARD}" == "arm64-usr" ]]; then
   PACKET_REGION="DA"
-  PARALLEL_TESTS="3"
 fi
 
 # Run the cl.internet test on multiple machine types only if it should run in general


### PR DESCRIPTION
- jenkins/kola/azure.sh: Align the timeout with the GC duration
    
    The kola test run time shouldn't be longer than the GC duration to
    prevent failing tests caused by GC interference.
    Align the Azure kola timeout with the GC duration.
- jenkins/kola/packet.sh: Remove hardcoded arm64 parallel test limit
    
    The arm64 tests on EM sometimes hit the timeout.
    Remove the hardcoded limit of 3 tests to default to 4 and otherwise
    use the overwritten parameter.

- ci-automation/vendor-testing/azure.sh: Align timeout with GC duration
    
    The kola test run time shouldn't be longer than the GC duration to
    prevent failing tests caused by GC interference.
    Align the Azure kola timeout with the GC duration.


## How to use

Pick for all channels

## Testing done

None

