### PR TITLE
Make qemu_template.sh work on macOS

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -11,7 +11,7 @@ VM_MEMORY=
 VM_CDROM=
 VM_PFLASH_RO=
 VM_PFLASH_RW=
-VM_NCPUS="$(nproc)"
+VM_NCPUS="$(getconf _NPROCESSORS_ONLN)"
 SSH_PORT=2222
 SSH_KEYS=""
 CLOUD_CONFIG_FILE=""
@@ -111,7 +111,7 @@ write_ssh_keys() {
 
 
 if [ -z "${CONFIG_IMAGE}" ]; then
-    CONFIG_DRIVE=$(mktemp -t -d flatcar-configdrive.XXXXXXXXXX)
+    CONFIG_DRIVE=$(mktemp -d)
     ret=$?
     if [ "$ret" -ne 0 ] || [ ! -d "$CONFIG_DRIVE" ]; then
         echo "$0: mktemp -d failed!" >&2
@@ -156,7 +156,7 @@ else
     case "${VM_BOARD}+$(uname -m)" in
         amd64-usr+x86_64)
             # Emulate the host CPU closely in both features and cores.
-            set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@" ;;
+            set -- -machine accel=kvm:hvf:tcg -cpu host -smp "${VM_NCPUS}" "$@" ;;
         amd64-usr+*)
             set -- -machine pc-q35-2.8 -cpu kvm64 -smp 1 -nographic "$@" ;;
         arm64-usr+aarch64)


### PR DESCRIPTION
# Make qemu_template.sh work on macOS

Line 14; The nproc command is only available on systems with GNU coreutils installed. The getconf _NPROCESSORS_ONLN alternative will work on a wider range of UNIX systems.
Line 114; The mktemp syntax used is not standaard and will only work with the GNU version of mktemp.
Line 159; added hvf (macOS) and tcg (no acceleration) options as a fallback. By doing this qemu-system-x86_64 will try to use kvm, but when it fails try hvf, and when that fails switch to the tcg accelerator.

## How to use

The proposed change should not change anything on systems where this script already worked, but is should now also work on macOS x86_64 and M1 systems using a recent version of qemu 

## Testing done

Changes tested on MacPro 5.1 running macOS 12.3.1 and QEMU emulator version 6.2.0 and 7.0.0
Also tested on a MacBook Pro 16-inch 2021 running macOS 13.0 Beta and QEMU emulator version 7.0.0


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
