### PR TITLE
.github: Run CI workflow only for PR events

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: "Run build"
 on:
-  push:
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Building for the branch push event causes two builds per PR and is not
needed anyway (we have nightly builds for the main branch).
Only consider PR events to trigger the CI build.
