### PR TITLE
ci-automation: align VM image compression with existing pipeline

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -105,10 +105,15 @@ function _vm_build_impl() {
 
     for format in ${formats}; do
         echo " ###################  VENDOR '${format}' ################### "
+        COMPRESSION_FORMAT="bz2"
+        if [[ "${format}" =~ ^(openstack|openstack_mini|digitalocean)$ ]];then
+            COMPRESSION_FORMAT="gz,bz2"
+        fi
         ./run_sdk_container -n "${vms_container}" -C "${image_image}" \
             -v "${vernum}" \
             ./image_to_vm.sh --format "${format}" --board="${arch}-usr" \
-                --from "${CONTAINER_IMAGE_ROOT}/${arch}-usr/latest"
+                --from "${CONTAINER_IMAGE_ROOT}/${arch}-usr/latest" \
+                --image_compression_formats="${COMPRESSION_FORMAT}"
     done
 
     # copy resulting images + push to buildcache


### PR DESCRIPTION
In jenkins/vms.sh the Digital Ocean and OpenStack images get also
compressed as gzip.
Do so for the new pipeline, too.

## Testing done

[done here](http://192.168.42.7:8080/job/container/job/packages/680/cldsv/) and checked that the additional gzip images get created for openstack/digitalocean (and get uploaded in https://bincache.flatcar-linux.net/images/amd64/9999.1.2+compression-formats-kai/)
