### PR TITLE
Add concurency setting to CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,10 @@ on:
           This is the ref we will use to pull the changes from the coreos_remote.
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }} 
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:


### PR DESCRIPTION
This change will prompt the CI workflow to cancel a currently running job for a PR, if a new push is sent to that PR while the job is till running. This should prevent duplicate jobs running for the same PR simultaneously.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>