### PR TITLE
ci-automation: Show changes by finding the previous channel

### DIFF
--- a/ci-automation/python-bin/python3
+++ b/ci-automation/python-bin/python3
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Expects to be invoked as interpreter through a shebang
+FOLDER="$(dirname "$(readlink -f "$1")")"
+docker pull docker.io/python:alpine 2>/dev/null >/dev/null
+# Map the current and the script folder, install the pip package needed for flatcar-build-scripts/show-fixed-kernel-cves.py
+exec docker run --rm -i -v "${FOLDER}:${FOLDER}" -v "${PWD}:${PWD}" -w "${PWD}" docker.io/python:alpine sh -c "pip install packaging 2>/dev/null >/dev/null; python3 $*"


### PR DESCRIPTION
The image comparison was done against the old release in the channel
we release to instead of the previous release with the same major
version. This means when a channel transition happens we see a large
diff instead of the diff against the previous release. While not bad
for finding problems, this is normally not needed. However, we want
to have two changelogs generated, one against the old release in the
channel we relese to and one against the previous release with the same
major version when a transition happens. There was no changelog
printing yet, and this is added now.

## How to use

backport

(when doing https://github.com/flatcar-linux/Flatcar/issues/794 this whole code block should gets its own function)

## Testing done

output is available in the [image job](http://192.168.42.7:8080/job/container/job/image/430/console)