### PR TITLE
ci-automation: Generate digests for artifacts

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -187,7 +187,8 @@ function docker_image_to_buildcache() {
     local tarball="$(basename "$image")-${version}.tar.gz"
 
     $docker save "${image}":"${version}" | $PIGZ -c > "${tarball}"
-    sign_artifacts "${SIGNER:-}" "${tarball}"
+    create_digests "${SIGNER:-}" "${tarball}"
+    sign_artifacts "${SIGNER:-}" "${tarball}"*
     copy_to_buildcache "containers/${version}" "${tarball}"*
 }
 # --

--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -347,6 +347,58 @@ function sign_artifacts() {
 }
 # --
 
+# Creates digests files and armored ASCII files out of them for the
+# passed files and directories. In case of directory, all files inside
+# it are processed. No new digests file is created if there is one
+# already for the processed file. Same for armored ASCII file. Files
+# ending with .asc or .sig or .gpg or .DIGESTS are not processed. The
+# armored ASCII files won't be created if the signer is empty.
+#
+# Typical use:
+#   create_digests "${SIGNER}" artifact.tar.gz
+#   sign_artifacts "${SIGNER}" artifact.tar.gz*
+#   copy_to_buildcache "artifacts/directory" artifact.tar.gz*
+#
+# Parameters:
+#
+# 1 - signer whose key is expected to be already imported into the
+#       keyring
+# @ - files and directories to create digests for
+function create_digests() {
+    local signer="${1}"; shift
+    # rest of the parameters are files or directories to create
+    # digests for
+    local to_digest=()
+    local file
+    local df
+    local af
+    local hash_type
+
+    list_files to_digest 'asc,gpg,sig,DIGESTS' "${@}"
+
+    for file in "${to_digest[@]}"; do
+        df="${file}.DIGESTS"
+        if [[ ! -e "${df}" ]]; then
+            touch "${df}"
+            # TODO: modernize - drop md5 and sha1, add b2
+            for hash_type in md5 sha1 sha512; do
+                echo "# ${hash_type} HASH" | tr "a-z" "A-Z" >> "${df}"
+                "${hash_type}sum" "${file}" >> "${df}"
+            done
+        fi
+        if [[ -z "${signer}" ]]; then
+            continue
+        fi
+        af="${df}.asc"
+        if [[ ! -e "${af}" ]]; then
+            gpg --batch --local-user "${signer}" \
+                --output "${af}" \
+                --clearsign "${df}"
+        fi
+    done
+}
+# --
+
 # Puts a filtered list of files from the passed files and directories
 # in the passed variable. The filtering is done by ignoring files that
 # end with the passed extensions. The extensions list should not

--- a/ci-automation/image.sh
+++ b/ci-automation/image.sh
@@ -39,6 +39,7 @@
 #   2. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 #   3. If signer key was passed, signatures of artifacts from point 1, pushed along to buildcache.
+#   4. DIGESTS of the artifacts from point 1, pushed to buildcache. If signer key was passed, armored ASCII files of the generated DIGESTS files too, pushed to buildcache.
 
 function image_build() {
     # Run a subshell, so the traps, environment changes and global
@@ -105,6 +106,7 @@ function _image_build_impl() {
 
     # Delete uncompressed generic image before signing and upload
     rm "images/latest/flatcar_production_image.bin" "images/latest/flatcar_production_update.bin"
+    create_digests "${SIGNER}" "images/latest/"*
     sign_artifacts "${SIGNER}" "images/latest/"*
     copy_to_buildcache "images/${arch}/${vernum}/" "images/latest/"*
 

--- a/ci-automation/packages.sh
+++ b/ci-automation/packages.sh
@@ -64,6 +64,7 @@
 #   3. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 #   4. If signer key was passed, signatures of artifacts from point 1, pushed along to buildcache.
+#   5. DIGESTS of the artifacts from point 1, pushed to buildcache. If signer key was passed, armored ASCII files of the generated DIGESTS files too, pushed to buildcache.
 
 function packages_build() {
     # Run a subshell, so the traps, environment changes and global
@@ -175,9 +176,12 @@ function _packages_build_impl() {
     docker_commit_to_buildcache "${packages_container}" "${packages_image}" "${docker_vernum}"
 
     # Publish torcx manifest and docker tarball to "images" cache so tests can pull it later.
-    sign_artifacts "${SIGNER}" \
+    create_digests "${SIGNER}" \
         "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json" \
         "${torcx_tmp}/torcx/pkgs/${arch}-usr/docker/"*/*.torcx.tgz
+    sign_artifacts "${SIGNER}" \
+        "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json"* \
+        "${torcx_tmp}/torcx/pkgs/${arch}-usr/docker/"*/*.torcx.tgz*
     copy_to_buildcache "images/${arch}/${vernum}/torcx" \
         "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json"*
     copy_to_buildcache "images/${arch}/${vernum}/torcx" \

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -56,6 +56,7 @@
 #   3. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 #   4. If signer key was passed, signatures of artifacts from point 1, pushed along to buildcache.
+#   5. DIGESTS of the artifacts from point 1, pushed to buildcache. If signer key was passed, armored ASCII files of the generated DIGESTS files too, pushed to buildcache.
 
 function sdk_bootstrap() {
     # Run a subshell, so the traps, environment changes and global
@@ -141,9 +142,11 @@ function _sdk_bootstrap_impl() {
     local uid=$(id --user)
     local gid=$(id --group)
     sudo chown --recursive "${uid}:${gid}" __build__
-    cd "__build__/images/catalyst/builds/flatcar-sdk"
-    sign_artifacts "${SIGNER}" "${dest_tarball}"*
-    copy_to_buildcache "sdk/${ARCH}/${FLATCAR_SDK_VERSION}" "${dest_tarball}"*
-    cd -
+    (
+      cd "__build__/images/catalyst/builds/flatcar-sdk"
+      create_digests "${SIGNER}" "${dest_tarball}"
+      sign_artifacts "${SIGNER}" "${dest_tarball}"*
+      copy_to_buildcache "sdk/${ARCH}/${FLATCAR_SDK_VERSION}" "${dest_tarball}"*
+    )
 }
 # --

--- a/ci-automation/sdk_container.sh
+++ b/ci-automation/sdk_container.sh
@@ -37,6 +37,7 @@
 #   2. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 #   3. If signer key was passed, signatures of artifacts from point 1, pushed along to buildcache.
+#   4. DIGESTS of the artifacts from point 1, pushed to buildcache. If signer key was passed, armored ASCII files of the generated DIGESTS files too, pushed to buildcache.
 
 function sdk_container_build() {
     # Run a subshell, so the traps, environment changes and global

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -42,6 +42,7 @@
 #   2. "./ci-cleanup.sh" with commands to clean up temporary build resources,
 #        to be run after this step finishes / when this step is aborted.
 #   3. If signer key was passed, signatures of artifacts from point 1, pushed along to buildcache.
+#   4. DIGESTS of the artifacts from point 1, pushed to buildcache. If signer key was passed, armored ASCII files of the generated DIGESTS files too, pushed to buildcache.
 
 function vm_build() {
     # Run a subshell, so the traps, environment changes and global
@@ -131,6 +132,7 @@ function _vm_build_impl() {
         -v "${vernum}" \
         mv "${CONTAINER_IMAGE_ROOT}/${arch}-usr/" "./${images_out}/"
 
+    create_digests "${SIGNER}" "images/latest/"*
     sign_artifacts "${SIGNER}" "images/latest/"*
     copy_to_buildcache "images/${arch}/${vernum}/" "images/latest/"*
 }


### PR DESCRIPTION
This PR adds generation of DIGESTS files and their armored ASCII file counterparts for the built artifacts (images, container tarballs). The only artifacts for which the DIGESTS files are not created are Gentoo packages in the "push packages" job. Not sure if it's worthwhile, because the Packages file already serves as a kinda-sorta-DIGESTS-file, and it's signed by us.

## How to use

Run the build (or use the CI build from below), see if the generated artifacts have DIGESTS and asc files next to them for sdk, packages, image and vms jobs.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/129/cldsv/