### PR TITLE
build_library/build_image_util.sh: Try to clean up unused stuff

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -31,6 +31,7 @@ set_build_symlinks() {
 cleanup_mounts() {
   info "Cleaning up mounts"
   "${BUILD_LIBRARY_DIR}/disk_util" umount "$1" || true
+  rmdir "${1}" || true
 }
 
 delete_prompt() {
@@ -782,5 +783,6 @@ EOF
     pushd "${BUILD_DIR}" >/dev/null
     zip --quiet -r -9 "${BUILD_DIR}/${pcr_policy}" pcrs
     popd >/dev/null
+    rm -rf "${BUILD_DIR}/pcrs"
   fi
 }

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -513,6 +513,8 @@ install_oem_aci() {
         "${aci_path}" \
         "${VM_TMP_ROOT}/usr/share/oem/flatcar-oem-${oem_aci}.aci" ||
     die "Could not install ${oem_aci} OEM ACI"
+    # Remove aci_dir if building ACI and installing it succeeded
+    rm -rf "${aci_dir}"
 }
 
 # Any other tweaks required?


### PR DESCRIPTION
There is some cruft left after grub hashes generation. After the
contents are zipped into archive, they don't need to be around any
more.

Try to remove the rootfs directory after unmounting the
image. disk_util can recreate it again if there is a need for it.

Remove the build directory used for generating ACI images - it's not
needed after successful installation.

Fixes https://github.com/flatcar-linux/Flatcar/issues/801.


## Testing done

Running builds with old and new pipeline:
- http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6056/cldsv/
- http://jenkins.infra.kinvolk.io:8080/job/container/job/packages/792/cldsv/