### PR TITLE
add SPDX SBOM generation using syft

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -311,6 +311,12 @@ write_packages() {
     image_packages "$1" | sort > "$2"
 }
 
+# Generate an SPDX SBOM using syft
+write_sbom() {
+    info "Writing ${2##*/}"
+    sudo syft packages "${1}" -o spdx-json="$2"
+}
+
 # Get metadata $key for package $pkg installed under $prefix
 # The metadata is either read from the portage db folder or
 # via a portageq-BOARD invocation. In cases where SRC_URI is

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -65,6 +65,7 @@ create_prod_image() {
   local root_fs_dir="${BUILD_DIR}/rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_packages="${image_name%.bin}_packages.txt"
+  local image_sbom="${image_name%.bin}_sbom.json"
   local image_licenses="${image_name%.bin}_licenses.json"
   local image_kconfig="${image_name%.bin}_kernel_config.txt"
   local image_kernel="${image_name%.bin}.vmlinuz"
@@ -81,6 +82,7 @@ create_prod_image() {
   run_ldconfig "${root_fs_dir}"
   run_localedef "${root_fs_dir}"
   write_packages "${root_fs_dir}" "${BUILD_DIR}/${image_packages}"
+  write_sbom "${root_fs_dir}" "${BUILD_DIR}/${image_sbom}"
   write_licenses "${root_fs_dir}" "${BUILD_DIR}/${image_licenses}"
   insert_licenses "${BUILD_DIR}/${image_licenses}" "${root_fs_dir}"
 
@@ -137,6 +139,7 @@ EOF
   local to_upload=(
     "${BUILD_DIR}/${image_contents}"
     "${BUILD_DIR}/${image_packages}"
+    "${BUILD_DIR}/${image_sbom}"
     "${BUILD_DIR}/${image_licenses}"
     "${BUILD_DIR}/${image_kernel}"
     "${BUILD_DIR}/${image_pcr_policy}"


### PR DESCRIPTION
# add SPDX SBOM generation using syft

Since v0.51.0 syft supports generating parsing the gentoo package
database. This is a first go at integrating that into our image build
process. This doesn't yet include packages inside torcx packages, or the
kernel, or initramfs-only packages.

- [x] Requires https://github.com/flatcar-linux/coreos-overlay/pull/2030

## How to use

```
./build_image --board=amd64-usr
ls -la ~/trunk/src/build/image/amd64-usr/latest/flatcar_production_image_sbom.json
```

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
