### PR TITLE
.github: Specify remote when checking out c-o/p-s ref in workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
             [[ "$REMOTE" == "https:*" ]] || REMOTE="https://github.com/${COREOS_REMOTE}"
             git -C "$REPO_PATH" remote add test "$REMOTE"
             git -C "$REPO_PATH" fetch test
-            git -C "$REPO_PATH" checkout "${COREOS_REF}"
+            git -C "$REPO_PATH" checkout "test/${COREOS_REF}"
           fi
 
           if [ "${PORTAGE_REMOTE}" != "" -a  "${PORTAGE_REF}" != "" ]
@@ -122,7 +122,7 @@ jobs:
             [[ "$REMOTE" == "https:*" ]] || REMOTE="https://github.com/${PORTAGE_REMOTE}"
             git -C "$REPO_PATH" remote add test "$REMOTE"
             git -C "$REPO_PATH" fetch test
-            git -C "$REPO_PATH" checkout "${PORTAGE_REF}"
+            git -C "$REPO_PATH" checkout "test/${PORTAGE_REF}"
           fi 
 
       - name: Build packages


### PR DESCRIPTION
When the specified remote contains a same-named branch as origin,
the checkout fails with "fatal: 'X' matched multiple (Y) remote
tracking branches".
Add the remote name as prefix to make the reference unambiguous.

## How to use
backport 

## Testing done

Trigger a build manually with a coreos-overlay reference. I guess we have to merge this first and then just verify if we don't want to test on a fork.