### PR TITLE
prod_image_util: extract gcc libs to /usr/lib64

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -45,7 +45,7 @@ extract_prod_gcc() {
     # Instead we extract them to plain old /usr/lib
     qtbz2 -O -t "${pkg}" | \
         sudo tar -C "${root_fs_dir}" -xj \
-        --transform 's#/usr/lib/.*/#/usr/lib/#' \
+        --transform 's#/usr/lib/.*/#/usr/lib64/#' \
         --wildcards './usr/lib/gcc/*.so*'
 
     package_provided "${gcc}"


### PR DESCRIPTION
# prod_image_util: extract gcc libs to /usr/lib64

This made no difference back when lib was a symlink to lib64, but now that they are separate,
libs belongs in /usr/lib64. This mostly doesn't show up because ldconfig configures the ld.so cache
to include both locations, but when updating from an older release ld.so.cache is out of date.
Unfortunately ld.so.cache does not get updated until after multipathd, which causes
multipathd to dump core. This may also affect other packages that need access to
libgcc early.

See also: https://github.com/flatcar-linux/Flatcar/issues/809

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
