### PR TITLE
ci-automation: Sync used EquinixMetal region to use for ARM64 servers

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -60,7 +60,7 @@ QEMU_UEFI_BIOS="${QEMU_UEFI_BIOS:-flatcar_production_qemu_uefi_efi_code.fd}"
 EQUINIXMETAL_PARALLEL="${PARALLEL_TESTS:-4}"
 # Metro is a set of Equinix Metal regions
 EQUINIXMETAL_amd64_METRO="${EQUINIXMETAL_amd64_METRO:-SV}"
-EQUINIXMETAL_arm64_METRO="${EQUINIXMETAL_arm64_METRO:-DA}"
+EQUINIXMETAL_arm64_METRO="${EQUINIXMETAL_arm64_METRO:-DC}"
 # Name of the Equinix Metal image
 EQUINIXMETAL_IMAGE_NAME="flatcar_production_packet_image.bin.bz2"
 # Storage URL required to store user-data


### PR DESCRIPTION
Recently we changed the region from DA (Dallas) to DC (Washington),
because there are more ARM64 servers available. Reflect this change in
the new pipeline too.
