### PR TITLE
Cover Equinix Metal m3.small.x86 instances in release test

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -69,7 +69,7 @@ EQUINIXMETAL_STORAGE_URL="${EQUINIXMETAL_STORAGE_URL:-gs://flatcar-jenkins/mantl
 EQUINIXMETAL_amd64_INSTANCE_TYPE="${EQUINIXMETAL_amd64_INSTANCE_TYPE:-c3.small.x86}"
 # Space separated list of instance types. On those instances the
 # cl.internet kola test will be run if this test is selected to run.
-EQUINIXMETAL_amd64_MORE_INSTANCE_TYPES="c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86"
+EQUINIXMETAL_amd64_MORE_INSTANCE_TYPES="m3.small.x86 c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86"
 # Equinix Metal default ARM64 instance type
 EQUINIXMETAL_arm64_INSTANCE_TYPE="c3.large.arm"
 # Space separated list of instance types. On those instances the

--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -41,7 +41,7 @@ fi
 # Run the cl.internet test on multiple machine types only if it should run in general
 cl_internet_included="$(set -o noglob; bin/kola list --platform=packet --filter ${KOLA_TESTS} | { grep cl.internet || true ; } )"
 if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_internet_included}" != ""  ]]; then
-  for INSTANCE in c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
+  for INSTANCE in m3.small.x86 c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
     (
     set +x
     OUTPUT=$(timeout --signal=SIGQUIT "${timeout}" bin/kola run \


### PR DESCRIPTION
The new m3.small instance does not have official Flatcar support yet
but we can already cover it in our PXE boot release tests.
The c3.small instances are legacy and m3.small is the new smallest
type.


## How to use

- Test that it works
- Backport

## Testing done

started something [here](http://192.168.42.7:8080/job/container/job/test/2076/console)
